### PR TITLE
Docs: document the 'use server-entry' directive

### DIFF
--- a/apps/website/content/docs/pages.md
+++ b/apps/website/content/docs/pages.md
@@ -117,6 +117,58 @@ are soft navigations, so client state outside the changed subtree survives. Hist
 half alone. Both are `'use client'` modules a server component can render directly. A `redirect()` is
 never absorbed by either — it is navigation, not failure.
 
+## The `'use server-entry'` directive
+
+`'use server-entry'` marks a module as the entry point for its route. The build follows the imports out of
+it, collects the client JS and CSS they reach, and hangs that list on the component itself — which is what
+the renderer hands React as `bootstrapScripts`. That is how each page ships its own bundle and no other
+page's, with no asset manifest in between.
+
+You almost never write it. The build injects it for every page reached through an **inline** thunk in
+`routes.ts`:
+
+```ts
+{ path: '/profile/:id', component: () => import('./components/profile') }
+```
+
+_Inline_ is literal: the arrow function and the `import()` both spelled out at the `component` key, with a
+string literal for the specifier. `async () => import('…')` counts, and the specifier may be relative or
+`@/`-prefixed. Anything that cannot be read straight out of the source does not — a thunk held in a
+variable, a barrel re-export, a specifier assembled at runtime:
+
+```ts
+const profilePage = () => import('./components/profile');
+
+export const routes = defineRoutes([{ path: '/profile/:id', component: profilePage }]);
+```
+
+Wire a page up that way and the directive is yours to write, on the module's first line:
+
+```tsx
+'use server-entry';
+import type { PageProps } from '@rshono/core';
+
+export default function Profile({ params }: PageProps<'/profile/:id'>) {
+  return <Layout>{params.id}</Layout>;
+}
+```
+
+### A missing one fails at request time, not at build time
+
+Nothing looks for the directive while building. The module compiles, the build passes, and the first
+request to the route throws:
+
+```
+[rshono] The page component for "/profile/:id" is missing its client-asset info ('use server-entry').
+```
+
+A `render: 'static'` route is no exception. Its prerender fails, the build warns and falls back to
+[rendering the route per request](/docs/routing#static-rendering), and that request throws the same way.
+
+The injection also leaves alone any module that already opens with a directive, so a page module starting
+with `'use client'` is skipped and lands on the same error. A page is a server component: keep the
+interactive part in its own `'use client'` module and have the page render it.
+
 ## Server actions
 
 A `'use server'` module exports functions a client component can call directly, with typed arguments and

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -56,8 +56,9 @@ definition, not at runtime.
 Write `component` inline as `() => import('…')`. The framework detects that exact form and injects
 Rspack's `'use server-entry'` directive for you, which is what attaches each page's client JS and CSS to
 its component — per-route code splitting with no asset manifest. Wire a component up some other way
-(variable indirection, barrel re-exports, computed specifiers) and the build throws a descriptive error
-telling you to write the directive at the top of the page module yourself.
+(variable indirection, barrel re-exports, computed specifiers) and the directive is yours to write, at the
+top of the page module. See [the `'use server-entry'` directive](/docs/pages#the-use-server-entry-directive),
+which also covers what a missing one looks like.
 
 ## Static rendering
 


### PR DESCRIPTION
Fixes #20 

`PageRoute.component` links to `/docs/pages#the-use-server-entry-directive`, and that heading does not
exist. `router.ts` ships in the published `.d.ts`, so the dead link sits in the editor tooltip of every
installed rc.15. Writing the heading with exactly that text fixes it for the versions already on npm,
which is why the section goes in `pages.md` and nothing under `packages/` is touched.

The same change fixes a factual error one paragraph away. `routing.md` said the build throws when a
page is missing the directive. It does not: the only check is `loadPageModule`
(`entry.rsc.tsx:118`), so a dynamic route builds green and 500s on the first request, and a static
route gets a warning and a fallback to per-request rendering (`ssg.ts:150`) rather than a failed
build. That paragraph is now the field-level fact plus a link onward.

What the new section covers:

- what the directive does, and why it means per-route splitting with no asset manifest
- what counts as an inline thunk, matching the scan in `page-files.ts:9`: `async` is allowed, the
  specifier must be a string literal, relative or `@/`-prefixed
- writing it by hand, the escape hatch `test/fixtures/minimal-app` already covers
- the request-time failure with the real error text, and the static-route variant
- that a page module opening with `'use client'` is skipped by the injection
  (`page-entry-loader.cjs:2`) and lands on the same error

Verified by hand: the new heading slugifies to `the-use-server-entry-directive` under
`markdown.ts:216`, and `prettier --check` passes on both files. Worth flagging that `apps/website/**`
is outside the CI paths filter, so nothing in this PR runs on CI.