### PR TITLE
chore: rspack rsbuild to 2.2.0

### DIFF
--- a/packages/benchmarks/apps/rshono/package-lock.json
+++ b/packages/benchmarks/apps/rshono/package-lock.json
@@ -88,7 +88,7 @@
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.1.1",
-        "@rspack/core": "2.1.7",
+        "@rspack/core": "2.2.0",
         "@rspack/plugin-react-refresh": "2.0.2",
         "react-refresh": "0.18.0",
         "react-server-dom-rspack": "0.0.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,10 +61,10 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.1.1",
-    "@rspack/core": "2.1.7",
+    "@rspack/core": "2.2.0",
     "@rspack/plugin-react-refresh": "2.0.2",
     "react-refresh": "0.18.0",
-    "react-server-dom-rspack": "0.0.3"
+    "react-server-dom-rspack": "0.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@clack/prompts": "^1.7.0",
-    "@rspack/core": "2.1.7",
+    "@rspack/core": "2.2.0",
     "@types/node": "^26.2.0",
     "@rshono/core": "workspace:*",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Summary

- Upgrade `@rspack/core` from `2.1.7` to `2.2.0`.
- Upgrade `react-server-dom-rspack` from `0.0.3` to `0.1.0`.
- Rspack 2.2.0 introduces a breaking change that is incompatible with `react-server-dom-rspack@0.0.3`, so `react-server-dom-rspack` must be upgraded to `0.1.0` together with Rspack.