### PR TITLE
feature/harden for production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,31 @@ jobs:
         env:
           CREATE_RSHONO_E2E: '1'
 
+  coverage:
+    name: coverage floor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # A floor rather than a report, so a new branch cannot land untested. Scoped to `dist/**`: the report
+      # otherwise fills with the testbed's own bundle and the temp directories the e2e suites start servers
+      # from, neither of which is this package's code. Ubuntu only — one measurement of one tree is the
+      # gate, and the numbers do not differ by platform.
+      #
+      # It measures what the suite reaches *in process*. The e2e suites run the app in a child process, so
+      # what they exercise does not count towards it, and neither does the browser-only client runtime.
+      - name: Test with a coverage floor
+        run: pnpm --filter @rshono/core test:coverage
+
   browser:
     name: browser
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # A manifest pin is what a consumer resolves; an override is what this repo resolves. When they drift,
+      # the whole suite goes green against a resolution nobody publishes — so this runs before the gates that
+      # would report that false green.
+      - name: Check the exact pins agree
+        run: pnpm check:pins
+
       # The type-aware rules need the same modules `tsc` resolves, and the apps reach the framework
       # through its published `exports` — which point at `dist/`. Without this step every
       # `@rshono/core` import lints as an unresolved type and the run fills with `no-unsafe-*`.

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 .env*
 test-results/
 playwright-report/
+# Throwaway app copies the minimal-app suite builds inside the fixture — see `appWithRoutes`. Removed
+# when the run ends; ignored so a killed run cannot leave one staged.
+packages/core/test/fixtures/minimal-app/throwaway-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ those.
 
 ## [Unreleased]
 
+### Changed
+
+- **`@rspack/core` 2.1.7 → 2.2.0 and `react-server-dom-rspack` 0.0.3 → 0.1.0.** The two move as a pair —
+  `react-server-dom-rspack@0.1.0` declares a `@rspack/core: ^2.2.0-0` peer — and `0.1.0` is a minor on a
+  pre-1.0 package, so treat it as a breaking upstream change and read this entry before upgrading.
+
+  The manifests had already declared this pair since `6d8e3e4`, but the `pnpm-workspace.yaml` overrides and
+  the lockfile were left on 2.1.7 / 0.0.3. Because a manifest pin is what a consumer resolves and an override
+  is what this repo resolves, **the published versions had never been tested**: the suite, CI and every
+  fixture ran against the old pair while `npm i @rshono/core` installed the new one. The overrides and the
+  lockfile now name the same pair as the manifests, and the whole suite — including the scaffold job, which
+  installs a generated app from a registry with no overrides in play — is green against it.
+
+### Added
+
+- **`pnpm check:pins`**, which asserts the exactly-pinned dependencies agree across both published manifests,
+  the `pnpm-workspace.yaml` overrides, the lockfile and what is actually installed. It runs in CI before the
+  gates that would otherwise report a false green, and again in `pnpm release`, where `--skip-tests` cannot
+  skip it. Nothing compared those copies before, which is why the drift above lasted a month.
+
 ## [1.0.0-rc.17] - 2026-08-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,34 @@ those.
 
 ### Changed
 
-- **`@rspack/core` 2.1.7 → 2.2.0 and `react-server-dom-rspack` 0.0.3 → 0.1.0.** The two move as a pair —
+- **`@rspack/core` 2.1.7 → 2.2.1 and `react-server-dom-rspack` 0.0.3 → 0.1.0.** The two move as a pair —
   `react-server-dom-rspack@0.1.0` declares a `@rspack/core: ^2.2.0-0` peer — and `0.1.0` is a minor on a
   pre-1.0 package, so treat it as a breaking upstream change and read this entry before upgrading.
 
-  The manifests had already declared this pair since `6d8e3e4`, but the `pnpm-workspace.yaml` overrides and
-  the lockfile were left on 2.1.7 / 0.0.3. Because a manifest pin is what a consumer resolves and an override
-  is what this repo resolves, **the published versions had never been tested**: the suite, CI and every
-  fixture ran against the old pair while `npm i @rshono/core` installed the new one. The overrides and the
-  lockfile now name the same pair as the manifests, and the whole suite — including the scaffold job, which
-  installs a generated app from a registry with no overrides in play — is green against it.
+  The manifests had already declared 2.2.0 / 0.1.0 since `6d8e3e4`, but the `pnpm-workspace.yaml` overrides
+  and the lockfile were left on 2.1.7 / 0.0.3. Because a manifest pin is what a consumer resolves and an
+  override is what this repo resolves, **the published versions had never been tested**: the suite, CI and
+  every fixture ran against the old pair while `npm i @rshono/core` installed the new one. The overrides and
+  the lockfile now name the same pair as the manifests, and the whole suite — including the scaffold job,
+  which installs a generated app from a registry with no overrides in play — is green against it.
+
+  `react-server-dom-rspack` stays at **0.1.0**, which is its `latest`. There is a `19.3.0` on npm, but it is
+  tagged `canary` and peers `react: ^19.3.0` / `react-dom: ^19.3.0` — versions that exist only as React
+  canaries — so taking it would mean shipping a stable framework on a React canary. `react`, `react-dom` and
+  `hono` are already at their latest stable releases and did not move.
+
+- **Every other dependency refreshed to its latest release.** `@types/node` `^26.2.0` → `^26.4.0` (which
+  `FRAMEWORK_DEPS` carries into scaffolded apps), `@types/react-dom` `^19.2.4` → `^19.2.5`, `eslint`
+  `^10.8.1` → `^10.9.1`, `typescript-eslint` `^8.67.0` → `^8.68.0`, and for the website `markdown-it`
+  `^15.0.1`, `@types/markdown-it` `^14.2.0`, `wrangler` `^4.127.1`.
+
+  The website's own `typescript` moves `~6.0.3` → `^7.0.2`, matching `packages/core` and `apps/testbed`. Its
+  `tsconfig.json` was already written for 7 — the `paths`-without-`baseUrl` comment says so — and it
+  typechecks clean, so the 6.x pin was an oversight rather than a constraint.
+
+  **The root `typescript` stays on `~6.0.3`.** It is there for the linter, and `typescript-eslint@8.68.0` —
+  the latest — still peers `typescript >=4.8.4 <6.1.0`. Nothing to do until that range widens; see
+  CONTRIBUTING.md, "Two TypeScripts".
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,11 @@ those.
 
 ## [Unreleased]
 
-A production-readiness pass over `@rshono/core` ahead of 1.0.0. Two independent reviews of the package were
-consolidated, re-verified against the tree, and worked through: four blockers, the security boundaries
-`SECURITY.md` commits to, ten correctness bugs, the robustness of the streaming path, the parts of the public
-surface that cannot change after 1.0.0 without a major, and the test gaps under all of it. The suite went from
-192 tests over 30 suites to 281 over 42, and coverage now has a floor.
-
-**If you are upgrading**, the two entries that can require a change are the `@rspack/core` /
-`react-server-dom-rspack` pair below and `HTTPMethod` losing `'head'`.
-
 ### Changed
 
 - **`@rspack/core` 2.1.7 → 2.2.1 and `react-server-dom-rspack` 0.0.3 → 0.1.0.** The two move as a pair —
   `react-server-dom-rspack@0.1.0` declares a `@rspack/core: ^2.2.0-0` peer — and `0.1.0` is a minor on a
   pre-1.0 package, so treat it as a breaking upstream change and read this entry before upgrading.
-
-  The manifests had already declared 2.2.0 / 0.1.0 since `6d8e3e4`, but the `pnpm-workspace.yaml` overrides
-  and the lockfile were left on 2.1.7 / 0.0.3. Because a manifest pin is what a consumer resolves and an
-  override is what this repo resolves, **the published versions had never been tested**: the suite, CI and
-  every fixture ran against the old pair while `npm i @rshono/core` installed the new one. The overrides and
-  the lockfile now name the same pair as the manifests, and the whole suite — including the scaffold job,
-  which installs a generated app from a registry with no overrides in play — is green against it.
 
   `react-server-dom-rspack` stays at **0.1.0**, which is its `latest`. There is a `19.3.0` on npm, but it is
   tagged `canary` and peers `react: ^19.3.0` / `react-dom: ^19.3.0` — versions that exist only as React

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ those.
 
 ## [Unreleased]
 
+A production-readiness pass over `@rshono/core` ahead of 1.0.0. Two independent reviews of the package were
+consolidated, re-verified against the tree, and worked through: four blockers, the security boundaries
+`SECURITY.md` commits to, ten correctness bugs, the robustness of the streaming path, the parts of the public
+surface that cannot change after 1.0.0 without a major, and the test gaps under all of it. The suite went from
+192 tests over 30 suites to 281 over 42, and coverage now has a floor.
+
+**If you are upgrading**, the two entries that can require a change are the `@rspack/core` /
+`react-server-dom-rspack` pair below and `HTTPMethod` losing `'head'`.
+
 ### Changed
 
 - **`@rspack/core` 2.1.7 → 2.2.1 and `react-server-dom-rspack` 0.0.3 → 0.1.0.** The two move as a pair —
@@ -42,12 +51,136 @@ those.
   the latest — still peers `typescript >=4.8.4 <6.1.0`. Nothing to do until that range widens; see
   CONTRIBUTING.md, "Two TypeScripts".
 
+- **`HTTPMethod` no longer offers `'head'`.** Hono dispatches a `HEAD` as a `GET` and strips the body off the
+  response, so a route registered for `HEAD` answered nothing — verified: `app.on('HEAD', …)` 404s the `HEAD`
+  _and_ the `GET`. The value type-checked, built and silently 404'd. Use `method: 'get'`, which answers both;
+  `src/routes.ts` validation now says so by name if it finds a `'head'`.
+
+- **`src/routes.ts` and `src/server.ts` are validated rather than cast.** Both reach the framework through a
+  build-time alias with no type the compiler can hold, so a mistake used to surface later and elsewhere — a
+  `routes` array that skipped `defineRoutes` as `TypeError: nN is not iterable` out of a minified bundle. Every
+  message now names the file, the entry by position _and_ path, and what to do. Two mistakes that produced no
+  error at all are refused as well: a key belonging to the other kind of route, and a route every method of
+  which an earlier one already answers.
+
+- **`ServerErrorContext` carries the request's Hono context and a `waitUntil`.** Reporting is what
+  `onServerError` exists for, and on a serverless platform a report started there was cut off when the
+  response ended. `waitUntil` holds the invocation open where the platform has such a thing to ask; `hono`
+  gives a handler `hono.var` — a request id to correlate on — which it had no way to reach for a
+  `source: 'request'` error, reported outside the ambient context. Both types are now generic over the app's
+  `Env`, defaulting so nothing existing changes.
+
+- **The prerender pass renders eight paths at a time and de-duplicates.** A documentation site with a few
+  hundred `staticPaths` entries paid every page's data fetching in series, and a repeated entry was rendered
+  and written twice with nothing said. Results, the manifest and the build log are folded back in route order,
+  so a concurrent pass reads like a serial one.
+
+- **The flight injector honours the consumer's demand.** The payload pump wrote into the response from a
+  detached promise with nothing consulting demand: a client that read one chunk and stalled still pulled the
+  whole payload into memory. It now takes one permit per chunk the consumer asks for, so a slow client parks
+  React instead of filling the process.
+
+- **A `render: 'static'` route the build wrote nothing for no longer pays a store lookup per request.** The
+  build leaves a manifest naming every file it wrote, and the runtime reads it once.
+
+- **`staticPaths` is checked against its own route's path.** A param key the path does not have is a type
+  error where the route is declared, rather than a build-time throw from the prerender pass. Keys only, so a
+  `staticPaths` annotated as returning `Record<string, string>` — the type the field declares — still
+  compiles.
+
 ### Added
+
+- **`method` on an endpoint route takes a list.** `method: ['get', 'delete']` is one handler for two methods;
+  before, a two-method endpoint had to be `'all'` plus a hand-rolled check, which also answered every method
+  it was not meant to. `'all'` inside a list is refused, as is an empty one.
 
 - **`pnpm check:pins`**, which asserts the exactly-pinned dependencies agree across both published manifests,
   the `pnpm-workspace.yaml` overrides, the lockfile and what is actually installed. It runs in CI before the
   gates that would otherwise report a false green, and again in `pnpm release`, where `--skip-tests` cannot
   skip it. Nothing compared those copies before, which is why the drift above lasted a month.
+
+- **`pnpm --filter @rshono/core test:coverage`**, the suite against a coverage floor over `dist/**`, and a CI
+  job that runs it. Nothing measured coverage before, so a new branch could land untested.
+
+### Fixed
+
+- **Prerendered pages whose paths need percent-encoding were built and then never served.** The build wrote
+  each page under `encodeURIComponent(value)` while Hono hands a handler a path it has already run
+  `decodeURI` over, so writer and reader disagreed for exactly the characters `decodeURI` unescapes: every
+  non-ASCII or space-bearing slug was reported as prerendered and missed on every request, forever, and
+  differently per deploy target. One mapping now answers for both, and stores each segment decoded.
+
+- **`PORT=""` bound a random port and reported success.** The CLI treated an empty `PORT` as unset while the
+  node bundle turned it into `0`. Both now parse it the same way, and a `PORT` that is not a usable port is a
+  named error rather than a silent bind — an empty `PORT` is common in CI images and container templates.
+
+- **An action that failed before its payload was produced made the browser throw a `TypeError`.** A
+  `bodyLimit()` 413, a proxy error page or a 502 mid-deploy all reached application code as
+  `Error: Connection closed.`, with the status nowhere in sight. A response that is not a flight payload now
+  surfaces its status, and an action that threw is answered with a payload the client can act on.
+
+- **A `notFound` or `error` page that itself threw a control signal produced a bodiless, unlogged 500.** Both
+  are now answered — reported, and with a body — and a `notFound` page calling `notFound()` recurses exactly
+  once.
+
+- **A `redirect()` or `notFound()` raised after the shell had flushed kept rendering a page nobody would
+  see.** HTTP has no take-backs once the status line is out, so the signal still rides the payload for the
+  client runtime to act on — but the render is now aborted rather than run to completion, and `rshono dev`
+  warns with the page and the destination. The limitation and its app-side fix are in the README.
+
+- **A `HEAD` on a page route rendered the whole document and threw it away.** Hono drops the body without
+  reading it, so nothing cancelled the render: the abort forwarder stayed attached to the request signal,
+  holding the rendered tree. A `HEAD` now takes the same path a `GET` would — prerendered bytes included, so
+  it promises the same `ETag` and `Content-Length` — and the render behind it is released.
+
+- **A plain-text 404 or 500 carried no `Cache-Control`.** The framework's default is applied to page content
+  types, so these two never got one — and a 404 is heuristically cacheable, meaning a shared cache was free to
+  store it while the rendered HTML 404 beside it was correctly private.
+
+- **A route that cannot be prerendered no longer fails the whole build.** A wildcard segment, an
+  optional/regex param or a `staticPaths` that rejected took the build down with a raw error; each is now a
+  warning naming the reason, and the route renders per request like any other. What still fails the build is a
+  `staticPaths` _value_ no single file can hold, which would otherwise be reported as prerendered and never
+  served.
+
+- **The injected flight payload could land inside `</body></html>`.** The trailer was looked for on each
+  batch, so one split across two batches was missed. Anything that could still become the trailer is now held
+  back and carried into the next batch.
+
+- **A soft navigation to an unmatched path got a payload without `notFound: true`.** The flag was set on one
+  of the two routes to the same page; both set it now.
+
+### Security
+
+- **The SSR env shadow covers every way a client component can read the environment.** The loader skipped any
+  module whose source did not contain the literal `process.env`, so `process?.env` — the spelling used by
+  code meant to run in a browser _and_ on a server, which is exactly what a `'use client'` component is —
+  `process['env']`, `const { env } = process` and a plain alias all went through untouched, rendering real
+  secrets into the SSR'd HTML while the browser bundle saw the `PUBLIC_`-only view. The gate is now the
+  `process` binding itself, which the prelude replaces. A read through `globalThis.process`, which no binding
+  can shadow, is warned about in the app's own source.
+
+- **`/_static/*` is served behind `src/server.ts`'s middleware.** The asset handler was mounted ahead of the
+  app and is terminal, so asset responses carried the framework's three baseline headers and nothing else —
+  no CSP, no COOP, and no HSTS, which is per-response and exactly what a `/_static` request over http needs.
+
+- **The built-in form-post guard refuses a same-site cross-origin post, and one with no `Origin`.**
+  `same-site` is the label a browser sends from a sibling subdomain — a user-content host, a stale CNAME, a
+  subdomain takeover — and for an app with no `src/server.ts` there is no `csrf()` behind it. The guard now
+  proves same-origin rather than not-foreign, so a label with no `Origin` at all is refused too.
+
+- **The CSP nonce is validated before it is written into the payload script tag.** That tag is built by hand,
+  so its attribute value is the one in a rendered document nothing else escapes, and `secureHeadersNonce` is
+  an ordinary context variable any middleware can set. A value outside the base64/base64url alphabet is
+  dropped rather than escaped: a payload script the policy then refuses is the visible failure to have.
+
+- **The build warns when nothing in `src/` registers a body cap.** Every `'use server'` export is a public
+  POST endpoint and the action path buffers the whole body before it can decide anything about it. The warning
+  used to appear only when `src/server.ts` was absent entirely.
+
+- **`SECURITY.md` and the docs now say that a client-initiated action relies on the CORS preflight** for its
+  cross-origin protection, which is what the `x-rsc-action` header buys — and what an app widening `cors()`
+  gives up.
 
 ## [1.0.0-rc.17] - 2026-08-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,21 @@ pnpm check:pins                        # the exact pins agree: manifests, overri
 pnpm lint                              # one ESLint config, every package
 pnpm --filter @rshono/core typecheck
 pnpm --filter @rshono/core test        # unit + minimal-app + postcss + dev + production e2e + deploy targets
+pnpm --filter @rshono/core test:coverage # …the same, against a coverage floor over dist/**
 pnpm --filter @rshono/core test:browser  # Playwright: hydration, soft nav, actions, boundaries
 pnpm --filter @rshono/create test      # every combination of scaffolder options, asserted in memory
 CREATE_RSHONO_E2E=1 pnpm --filter @rshono/create test   # …and really installed and built
 ```
+
+`test:coverage` is `test` with a floor: it fails when line, branch or function coverage of `dist/**` drops
+below what is in `package.json`. It measures what the suite reaches **in process**, so the e2e suites — which
+run the app in a child process — contribute almost nothing to it, and neither does the browser-only client
+runtime. Raise the floor when a change lifts it; do not lower it to make a change fit.
+
+`test:browser` is a **separate** command and a separate CI job, not part of `pnpm test`: it needs Chromium.
+It is also the only coverage the client runtime has — soft navigation, hydration, the fatal overlay, an
+action's response reaching the browser — so a green local `pnpm test` says nothing about any of that. Run it
+before pushing a change to `src/runtime/entry.client.tsx` or to what a page sends the browser.
 
 CI runs all of it on Ubuntu and Windows, on Node 22 and 24. Windows is in the matrix because the framework
 resolves and compares absolute paths in several places, which is exactly where it breaks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,10 @@ typecheck` after `pnpm lint:fix`.
 - **`@rspack/core` and `react-server-dom-rspack` are pinned exactly, in `pnpm-workspace.yaml` overrides as
   well as in the manifests.** RSC internals are coupled across the two compilers and the two React builds; a
   split resolution fails inside minified React at render time. Don't bump them casually — a bump is a
-  release, and the whole suite is the check.
+  release, and the whole suite is the check. Move the manifests, the overrides and the lockfile in one commit:
+  a manifest pin is what a consumer resolves and an override is what this repo resolves, so drifting them
+  makes the suite green against a resolution nobody can install. `pnpm check:pins` is what holds them
+  together, and it runs in CI and again before a release.
 - **The apps import the framework through its published `exports`, which point at `dist/`.** A source change
   is invisible to them until `pnpm --filter @rshono/core build` has run. `pnpm dev` runs `tsc --watch` for
   exactly this.
@@ -48,6 +51,7 @@ typecheck` after `pnpm lint:fix`.
 ## Testing
 
 ```bash
+pnpm check:pins                        # the exact pins agree: manifests, overrides, lockfile, node_modules
 pnpm lint                              # one ESLint config, every package
 pnpm --filter @rshono/core typecheck
 pnpm --filter @rshono/core test        # unit + minimal-app + postcss + dev + production e2e + deploy targets

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -1,0 +1,1470 @@
+# Production readiness — `@rshono/core` 1.0.0
+
+Consolidated from two independent reviews of `packages/core` (49 modules, 5,444 LOC of `src/`), against the
+four release goals: a stable and bug-free API, a framework that is secure by default, a public surface that
+exposes only what is needed, and a suite that covers it.
+
+Every item below was **re-verified against the current working tree** while merging. Duplicates have been
+collapsed, stale line numbers corrected, and claims that did not survive re-checking are recorded in
+[Appendix A](#appendix-a--dismissed) rather than silently dropped.
+
+## Baseline (verified at merge time, branch `feature/harden-for-production`)
+
+| Check                              | Result                                                                                                                                                                                           |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pnpm --filter @rshono/core build` | ✅ clean                                                                                                                                                                                         |
+| `tsc --noEmit`                     | ✅ clean                                                                                                                                                                                         |
+| `pnpm lint`                        | ✅ clean                                                                                                                                                                                         |
+| `pnpm --filter @rshono/core test`  | ✅ 192 pass / 0 fail (30 suites, 8.7s)                                                                                                                                                           |
+| `test:browser` (Playwright)        | ⚠️ not run — no Chromium in this environment                                                                                                                                                     |
+| Installed vs. declared deps        | ✅ agree at `@rspack/core` 2.2.1 / `react-server-dom-rspack` 0.1.0 — [1.1](#11--blocker-the-published-dependency-versions-have-never-been-tested) resolved, and `pnpm check:pins` now holds them |
+
+The architecture holds up. The deploy seam (`DeployRuntime`), the layer-based env shadow, the control-signal
+digests, the abort-forwarding discipline in `renderComponent`, and the prerender store's byte-bounded cache
+are sound and well documented — the reasoning behind the hard parts is written down in the code itself, which
+is unusual and worth preserving. No `TODO`/`FIXME`/`HACK` markers, one `as unknown as` in the package, no
+tracked build artefacts.
+
+Everything below is either a defect reproduced against a real build or a gap between what the code does and
+what `README.md` / `SECURITY.md` say it does.
+
+**Provenance markers.** **[measured]** = reproduced against a running build, a direct call, or the installed
+Hono. **[by construction]** = follows from reading the code but was not executed.
+
+---
+
+## 1. Blockers
+
+### ~~1.1 — Blocker: the published dependency versions have never been tested~~ — ✅ resolved in `ee25131`
+
+- [x] ~~**`packages/core/package.json:64,67` declares `@rspack/core: 2.2.0` and `react-server-dom-rspack: 0.1.0`;
+      `pnpm-workspace.yaml:13-14` overrides resolve `2.1.7` and `0.0.3`. [measured]**~~
+
+  Verified installed: `packages/core/node_modules/@rspack/core` → **2.1.7**, `react-server-dom-rspack` →
+  **0.0.3**. Commit `6d8e3e4` ("chore: upgrade rspack to 2.2.0") moved the manifests and left the overrides
+  behind, so CI, the local suite and every fixture run against 2.1.7/0.0.3 while `npm i @rshono/core` gets
+  2.2.0/0.1.0. These are regular `dependencies`, not peers, so consumers cannot opt out. All four versions
+  exist on npm, so the package installs — it is simply untested, and `0.0.3 → 0.1.0` is a minor bump on a
+  `0.x` package, i.e. breaking by convention.
+
+  **Why it matters:** `packages/core/README.md:20-22` makes this exact promise — _"Both are pinned to exact
+  versions — in the manifests and in workspace overrides — and a release of rshono is what moves them, so an
+  upstream change reaches you as a tested release rather than as a broken install."_ Right now they moved
+  outside one. `ci.yml` says the same thing and does not check it.
+
+  **Knock-ons:** `packages/create/package.json:54` pins `2.2.0` for scaffolded apps and its `FRAMEWORK_DEPS`
+  codegen reads rshono's manifest, so generated apps inherit the same untested pair; the hand-written
+  `src/types/react-server-dom-rspack.d.ts` was authored against 0.0.3's surface; `packages/core/README.md:20`
+  still tells users `react-server-dom-rspack` "is still `0.0.x`".
+
+  **Fix:** pick one resolution; make the manifests, the overrides, the lockfile and the README agree; re-run
+  the full suite (including `scaffold` and `browser`); then add a CI step asserting `packages/core` +
+  `packages/create` deps equal the `pnpm-workspace.yaml` overrides. Nothing in `ci.yml` catches this drift
+  today.
+
+  > This item invalidates every other result in this document, including the 192 passing tests. Do it first.
+
+  #### Resolution — aligned **up**, to the pair the manifests already declared
+
+  The two peer-couple: `react-server-dom-rspack@0.1.0` declares `@rspack/core: ^2.2.0-0`, so they can only
+  move together, and the manifests already named the newer pair. The overrides and the lockfile were moved to
+  `2.2.0` / `0.1.0` to match, making the published resolution the tested one rather than reverting to a pair
+  that is now a month stale.
+
+  A follow-up commit (`c146e0c`) then took the whole tree to the latest available release, so `pnpm outdated -r`
+  is empty but for one entry that cannot move: **`@rspack/core` 2.2.1** (still satisfying the `^2.2.0-0` peer),
+  `@types/node` `^26.4.0`, `@types/react-dom` `^19.2.5`, `eslint` `^10.9.1`, `typescript-eslint` `^8.68.0`, and
+  the website's `markdown-it` / `@types/markdown-it` / `wrangler` / `typescript` (`~6.0.3` → `^7.0.2`, matching
+  core and testbed — its tsconfig was already authored for 7). Two ceilings are real and were verified, not
+  assumed:
+
+  - **`react-server-dom-rspack` stops at 0.1.0**, its `latest`. npm also carries a `19.3.0`, but it is tagged
+    `canary` and peers `react`/`react-dom` `^19.3.0` — versions that exist only as React canaries — so taking
+    it would put a stable framework on a React canary. `react`, `react-dom` and `hono` are already latest
+    stable.
+  - **The root `typescript` stays on `~6.0.3`**, because `typescript-eslint@8.68.0` — the latest — still peers
+    `typescript >=4.8.4 <6.1.0`. This is the documented "Two TypeScripts" constraint, re-confirmed against the
+    current release rather than taken from the comment. It also keeps
+    [7.3](#7-docs-and-repo-hygiene) (the root `baseUrl`) alive as written.
+
+  **Verified green at 2.2.1 / 0.1.0** _[measured]_ — `typecheck`, `pnpm lint`, **192/192** core tests
+  (30 suites), `testbed typecheck` against the built declarations, and the **`scaffold` e2e at 42/42**
+  (`CREATE_RSHONO_E2E=1`, 70.9s), which packs the framework, installs generated apps from a registry with
+  **no overrides in play**, and builds them — the consumer path this drift had made untested. Every export
+  the hand-written `src/types/react-server-dom-rspack.d.ts` declares was confirmed present in 0.1.0 on all
+  three entry points, so the declarations did not need widening.
+
+  **Not re-run:** `test:browser` — no Chromium in this environment. Still outstanding as
+  [8.3](#8-release-checklist).
+
+  **Guard added:** `pnpm check:pins` (`scripts/check-pinned-deps.mjs`) compares every exact pin across both
+  published manifests, the `pnpm-workspace.yaml` overrides, the lockfile and `node_modules`. It runs in the
+  CI `lint` job _before_ the gates that would otherwise report a false green, and inside `pnpm release`'s
+  version step, where `--skip-tests` cannot skip it. Confirmed to fail on a reconstruction of `6d8e3e4`'s
+  exact state, naming all three drifted files.
+
+  **Two claims in the knock-ons above did not survive checking**, recorded so they are not re-raised:
+  `packages/create`'s `@rspack/core` is a devDependency for bundling **its own** CLI
+  (`packages/create/rspack.config.mjs`, `scripts/build.mjs`), not something scaffolded apps receive; and
+  `FRAMEWORK_DEPS` never carried the pair — its `TEMPLATE_DEPS` list is `hono`, `react`, `react-dom`,
+  `typescript`, `@types/node`, `@types/react` only. Generated apps did inherit the untested pair, but
+  transitively through `@rshono/core`'s own `dependencies`, which is exactly what the `scaffold` job now
+  covers.
+
+  _Prose corrected with it (closes [7.1](#7-docs-and-repo-hygiene)):_ `packages/core/README.md:20`, the
+  website's `getting-started.md`, the `.d.ts` header and `packages/benchmarks/README.md` said
+  "`0.0.x`"/"`0.0.3`"; all four now say **pre-1.0**, which cannot rot to a stale digit again.
+
+### ~~1.2 — Blocker: prerendered pages whose params need percent-encoding are built and then never served~~ — ✅ resolved in `84f4897`
+
+- [x] ~~**`src/server/ssg.ts:55` writes the file under `encodeURIComponent(value)`, but Hono's `getPath` runs
+      `decodeURI` on any path containing `%` before the handler sees it. [measured]**~~
+
+  The two disagree for exactly the characters `decodeURI` unescapes. Verified end-to-end against
+  `dist/server/prerendered.js` and the installed Hono:
+
+  | `staticPaths` value | written to disk             | `c.req.path` at runtime | lookup key              | result   |
+  | ------------------- | --------------------------- | ----------------------- | ----------------------- | -------- |
+  | `plain`             | `docs/plain/index.html`     | `/docs/plain`           | `docs/plain/index.html` | HIT      |
+  | `café`              | `docs/caf%C3%A9/index.html` | `/docs/café`            | `docs/café/index.html`  | **MISS** |
+  | `a b`               | `docs/a%20b/index.html`     | `/docs/a b`             | `docs/a b/index.html`   | **MISS** |
+  | `ü`                 | `docs/%C3%BC/index.html`    | `/docs/ü`               | `docs/ü/index.html`     | **MISS** |
+  | `a/b`               | `docs/a%2Fb/index.html`     | `/docs/a%2Fb`           | `docs/a%2Fb/index.html` | HIT      |
+
+  So reserved characters survive and unreserved-but-escaped ones (all non-ASCII, spaces) do not — an invisible
+  line. The build reports the page as prerendered and every request silently falls back to SSR, forever.
+
+  **And the targets disagree.** Cloudflare's `readPrerendered` builds its key with `new URL(path, c.req.url)`
+  (`src/deploy/cloudflare/runtime.ts:36`), which _re-encodes_ non-ASCII — so Workers **hits** where
+  node/vercel/aws-lambda **miss**. Same build, same routes, different behaviour per target.
+
+  **Why it matters:** any non-ASCII slug (CJK, accented, Cyrillic) loses prerendering on three of the four
+  targets, with no error and no warning. Compounded by [3.7](#37--render-static-routes-the-build-skipped-still-take-the-prerendered-lookup-on-every-request):
+  every one of those misses is a failed `readFile` on every request, forever.
+
+  **Fix:** pick one canonical on-disk form — decode the path once and write/read decoded is simplest — and
+  assert the **round-trip** in a test rather than testing `interpolatePath` in isolation, which is what let
+  this through.
+
+  _Done as described._ `ssgFilePath` is now the single mapping from a path to the file holding its page — the
+  build's and every deploy target's — and decodes each segment, so the encoded and the decoded form of a path
+  resolve to the same file. `prerenderedRelPath` is gone into it; its traversal guard is subsumed and tightened
+  (`%2e%2e` is refused as the `..` it decodes to). Workers escapes the key back into a URL through the new
+  `ssgAssetPath`, so all four targets read what the build wrote. A segment that cannot be one portable file name
+  (`.`, `..`, empty, or holding `\ / : * ? " < > |` or a control character) is `null`: a miss for a request, and
+  a named build error where it used to be a `join(dir, null)` TypeError. Asserted as a round trip — the testbed
+  gained a `café` doc that `prod.test.mjs` and `cloudflare.test.mjs` both fetch percent-encoded.
+
+### ~~1.3 — Blocker: `HTTPMethod` advertises `'head'`, which can never match~~ — ✅ resolved in `7443826`
+
+- [x] ~~**`src/router.ts:220`. Hono rewrites `HEAD` to `GET` before routing, so a `'head'` registration is
+      unreachable. [measured]**~~
+
+  Verified against the installed Hono — and it is worse than "the `GET` handler wins". A route registered for
+  `HEAD` alone answers **nothing**:
+
+  ```
+  app.on('HEAD', '/headonly', …)   ->  HEAD /headonly  ->  404
+                                       GET  /headonly  ->  404
+  ```
+
+  **Why it matters:** `{ type: 'endpoint', method: 'head', … }` type-checks, builds, and silently 404s in
+  production for every method. It is a public type advertising a value that cannot work.
+
+  **Fix:** drop `'head'` from the union — a `HEAD` is already answered by the `'get'` handler with the body
+  stripped — and say so in the doc comment on `EndpointRoute.method` (`src/router.ts:213-214`). The same change
+  makes the internal `['GET', 'HEAD']` registrations at `src/server/static.ts:30`,
+  `src/deploy/filesystem.ts:47` and `src/deploy/cloudflare/runtime.ts:64,71` honest rather than
+  dead-but-plausible.
+
+  _Done as described,_ all four registrations included — each is now `app.get(…)`. `EndpointRoute.method` and
+  the `HTTPMethod` alias both say why there is no `'head'`, as do `docs/routing.md` and the API reference.
+  The testbed's `/api/quick-health` declares `method: 'get'` and `prod.test.mjs` sends it a `HEAD` — plus a
+  `public/` file and a hashed chunk — so the fact the removal rests on is asserted rather than assumed.
+  A runtime `method` that is not in the union is rejected by the validation pass added for
+  [1.4](#14--blocker-srcroutests-and-srcserverts-are-cast-not-validated), so a JS app cannot register the
+  unreachable route either.
+
+### ~~1.4 — Blocker: `src/routes.ts` and `src/server.ts` are cast, not validated~~ — ✅ resolved in `e1f34bf`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:40,53-54` cast the app's two entry modules straight to their types with no
+      check. [measured, by building real fixtures]**~~
+
+  | app mistake                                                                                           | what the developer sees                                                                                                        |
+  | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+  | `export const routes = [ … ]` without `defineRoutes` (an identity function, so this looks equivalent) | build fails with `TypeError: nN is not iterable` — a minified identifier, from a bundle, naming neither rshono nor `routes.ts` |
+  | `src/server.ts` default-exporting a non-Hono value                                                    | `TypeError: Cannot read properties of undefined (reading 'map')` from inside `app.route`                                       |
+  | **duplicate `path` values**                                                                           | **builds cleanly, exit 0, no warning** — the first registration silently shadows the second                                    |
+  | `render` / `staticPaths` on an `{ type: 'endpoint' }` route                                           | **type-checks** (excess-property checking against a union allows any key present in some member) and is silently ignored       |
+  | `staticPaths` on a `render: 'dynamic'` route                                                          | silently ignored                                                                                                               |
+
+  **Fix:** one validation pass over `routes` / `notFound` / `error`, ideally in `createConfigs` so it fails the
+  build with a `[rshono]` message naming the offending entry. Accept a bare array in `entry.rsc.tsx` too, since
+  the docs present it as a valid shape.
+
+  _(A missing or misnamed `routes` export needs nothing — Rspack already reports `ESModulesLinkingError:
+export 'routes' … was not found … (possible exports: table)`, which is better than anything we would write.)_
+
+  _Done,_ as `src/runtime/validate-entries.ts` — not in `createConfigs`, which never sees the route table:
+  the app's TypeScript is only evaluable once bundled. The pass runs at the server bundle's module load
+  instead, which covers all three entries into it — `rshono build` (it imports the bundle for the prerender
+  pass), `rshono dev` startup, and a deployed server booting — and `buildCommand` prints a `[rshono]` throw
+  from there as a message rather than as a stack through minified frames. Every row of the table above is now
+  a named refusal; a bare array is accepted. One judgement call beyond the brief: shadowing is decided per
+  **method**, and only when _all_ of a route's methods are already claimed, so `'get'` and `'post'` endpoints
+  on one path — and a catch-all behind a route claiming one method of it — stay legal. Covered by unit tests
+  over `validateRoutesModule`/`validateServerApp` and two builds in `minimal-app.test.mjs` that must exit 1.
+
+---
+
+## 2. Security
+
+`SECURITY.md` declares four boundaries the framework owns: the env split, action dispatch, the request context,
+and prerender traversal. The e2e suite proves the last two hold. Two items below land inside the first two.
+
+### ~~2.1 — The env shadow does not cover `process?.env`, `process['env']`, or an aliased `process`~~ — ✅ resolved in `fbce4a7`
+
+- [x] ~~**`src/builder/env-shadow-loader.cjs:33` skips any module whose source lacks the literal substring
+      `process.env`. [measured, by calling the built loader directly]**~~
+
+  | source shape                            | shadowed |
+  | --------------------------------------- | -------- |
+  | `process.env.DATABASE_URL`              | yes      |
+  | `const { DATABASE_URL } = process.env`  | yes      |
+  | `globalThis.process.env.DATABASE_URL`   | yes      |
+  | `process?.env.DATABASE_URL`             | **no**   |
+  | `process['env'].DATABASE_URL`           | **no**   |
+  | `const p = process; p.env.DATABASE_URL` | **no**   |
+
+  **Why it matters:** `process?.env` is not a contrived shape — it is the idiomatic way to write env access in
+  code meant to run in both a browser and a server, which is exactly what a `'use client'` component is. Such a
+  component is SSR'd in the `ssr` layer against the real `process`, so **the secret is rendered into the HTML
+  stream**; the browser bundle does not get the same value, so it is a hydration mismatch as well.
+  `SECURITY.md` puts this in scope: _"Anything that gets a non-prefixed variable into either is in scope."_
+
+  **Fix:** gate on `process` rather than `process.env` — the prelude is already a full `process` shadow, so it
+  covers all three shapes once it is emitted. Add the table above as a loader unit test.
+
+  _Done as described._ The gate is `/\bprocess\b/` behind an `includes('process')` fast path, so `preprocess`,
+  `processEnv` and `child_process` still cost one string scan and out. `const { env } = process` was a seventh
+  shape the table missed, and is covered too. The loader unit tests hold the whole table.
+
+  **One row of the table above was wrong**, and the fix does not change it: `globalThis.process.env` is _not_
+  shadowed and never was. The measurement behind that "yes" was whether the loader fires, not whether the read
+  is shadowed — the prelude is a module-scoped binding, and `globalThis.process` is the real `process` however
+  a module spells it (verified: the prelude evaluated against a real `process` returns the secret through
+  `globalThis.process.env` and `undefined` through `process.env`). Nothing a loader emits can close that: it
+  would take shadowing `globalThis` itself, and the real global cannot be captured in a scope that declares
+  `const globalThis` without hitting its own TDZ. So the loader now **warns** when a module under the app's
+  `src/` reads `process` through the global object — the app's own source only, since a library
+  feature-detecting `globalThis.process?.env?.NODE_ENV` is doing nothing wrong and has no app secret to read —
+  and `SECURITY.md`'s env-split bullet states the boundary rather than implying a tighter one. That warning
+  needed `rshono build` and `rshono dev` to print warnings at all: both used the `summary` preset, which counts
+  them and never shows them.
+
+  The pin is end to end as well as unit: the testbed's `leak-helper.ts` now reaches the env three ways and
+  never by the dotted spelling, so `prod.test.mjs`'s existing "secrets never reach the browser" assertion is
+  what fails if the gate narrows again — confirmed by rebuilding with the old gate restored, which renders the
+  real `DATABASE_URL` into the page.
+
+### ~~2.2 — `src/server.ts` middleware never runs for `/_static/*`~~ — ✅ resolved in `2fb87db`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:397` mounts static assets; `:401-403` mounts the app's sub-app _after_ it,
+      and the asset handler is terminal. [measured, against a real `rshono start` of `apps/testbed` with
+      `TESTBED_CSP=1`]**~~
+
+  ```
+  /                                CSP ✓   HSTS ✓   COOP ✓   X-Frame-Options ✓   nosniff ✓
+  /_static/chunks/main.<hash>.js   CSP —   HSTS —   COOP —   X-Frame-Options ✓   nosniff ✓
+  ```
+
+  Only the framework's three baseline headers (`entry.rsc.tsx:373-378`) reach an asset response.
+
+  **Why it matters:** HSTS is the one that materially matters — it is per-response, and a `/_static` request
+  over http is exactly where a downgrade lands. CSP and COOP are moot for a `.js` file, but their absence is
+  not something an operator will expect, and nothing documents it.
+
+  **Fix:** mount static assets _after_ `app.route('/', serverApp)` — they sit on a reserved prefix, so ordering
+  costs nothing — or state the exception in the README and lean on the CDN `_headers` the presets already
+  write.
+
+  _Done the first way._ `runtime.mountStaticAssets(app)` now runs below `app.route('/', serverApp)` and still
+  above the page routes, so an asset response goes through the app's middleware and no route can claim the
+  prefix. The flip side is the one mounting src/server.ts first always had, one path wider, and both halves of
+  it are now in the comment there: a terminal handler shadows a path, and unscoped middleware runs for
+  `/_static` too. `DeployRuntime.mountStaticAssets`'s doc said "ahead of the app's routes" and now says which
+  ones.
+
+  Pinned in `prod-config.test.mjs`, where the hardened profile already runs: an asset must carry HSTS, the
+  app's CSP and the testbed's own `X-Response-Time`, while keeping the immutable `Cache-Control` the asset
+  handler sets — the middleware wraps the handler rather than replacing it. Verified to fail with the old
+  order restored.
+
+### ~~2.3 — The built-in CSRF guard leaves a same-site cross-origin form post to `csrf()`~~ — ✅ resolved in `5f296e1`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:106-110` returns early unless `Sec-Fetch-Site` is exactly `cross-site`.
+      [measured, against a running minimal-app build with no `src/server.ts`, so no `csrf()`]**~~
+
+  ```
+  POST /  Sec-Fetch-Site: same-site   Origin: https://evil.app.test  ->  200   (not refused)
+  ```
+
+  This is **deliberate** — the doc comment at `:96` says so: _"`same-site` is left alone too, since a subdomain
+  policy is `csrf()`'s to express."_ The defect is not the code, it is the gap between the code and what
+  `SECURITY.md` leads a reader to expect.
+
+  **Why it matters:** `SECURITY.md`'s sentence — _"a cross-site form post to a server action, which it refuses
+  whether or not `csrf()` is registered"_ — is _literally_ accurate, since `cross-site` is the Fetch Metadata
+  term of art for a different registrable domain. But `same-site` is what a browser sends from a **sibling
+  subdomain**, so with no `csrf()` any subdomain — a user-content host, a stale CNAME, a subdomain takeover —
+  can drive any `'use server'` export with any arguments. A reader of that sentence will not expect that.
+
+  **Fix:** either compare `Origin` against `publicUrl(c).origin` whenever `Origin` is present (not only when
+  `Sec-Fetch-Site` says `cross-site`), or — if the subdomain policy is genuinely `csrf()`'s to own — reword
+  `SECURITY.md` so it says what the guard actually covers. Do not leave the sentence as it reads today.
+
+  _Both, and the code first._ The guard now treats `same-site` exactly as it treats `cross-site`, so it is the
+  `Origin` comparison that decides for either label. Comparing on `Origin` alone — the first option as written
+  — was rejected: it would drop the `same-origin` short-circuit, and a genuine post behind a proxy that
+  rewrites `Host` carries a public `Origin` against an internal `publicUrl(c)` whenever `trustProxy` is off.
+  The browser's own label is unforgeable by page script and settles that case; only the two labels that mean
+  "not from this origin" need the comparison at all.
+
+  `SECURITY.md` now says "a form post to a server action from another origin — a sibling subdomain included,
+  since `Sec-Fetch-Site: same-site` is what a browser labels that". The cost is stated in the guard's doc
+  comment: an app deliberately accepting a form post to an action from another origin of its own cannot,
+  `csrf()`'s allowlist included, and `{ type: 'endpoint' }` is what that app wants. `minimal-app.test.mjs` —
+  the app with no `src/server.ts`, where the framework guard is the only thing standing — covers the subdomain
+  shape, both labels paired with the app's own origin, and a `same-origin` post whose `Origin` a proxy
+  rewrote.
+
+### ~~2.4 — _(hardening)_ `refusesCrossSiteForm` allows `Sec-Fetch-Site: cross-site` with no `Origin`~~ — ✅ resolved in `a084b69`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:108-109` refuses only when `Origin` is _present and different_.**~~
+
+  Per Fetch, a browser always appends `Origin` to a non-GET/HEAD request (`null` under
+  `Referrer-Policy: no-referrer`, which the comparison already refuses), so **there is no browser shape that
+  reaches this** — it is not exploitable. But a security predicate should not fail open, and the guard reads as
+  though it covers the case.
+
+  **Fix:** refuse a `cross-site` label unless `Origin` positively proves same-origin. Add the shape to
+  `test/prod.test.mjs` beside the two already covered.
+
+  _Done as described._ Past the label check the comparison is unconditional, so no `Origin` and `Origin: null`
+  are both refused; the `same-origin` / `none` short-circuit still runs ahead of it, so a genuine post behind
+  a proxy that rewrote `Host` is untouched. Covered in `minimal-app.test.mjs` rather than `prod.test.mjs`: the
+  testbed registers `csrf()`, so a 403 there does not say which of the two refused it, while the minimal app
+  has no `src/server.ts` and the framework guard is the only thing standing.
+
+### ~~2.5 — _(hardening)_ The CSP nonce is interpolated into raw HTML unvalidated~~ — ✅ resolved in `afb4748`
+
+- [x] ~~**`src/runtime/flight-inject.ts:73` writes `nonce="${nonce}"` into a `<script>` tag it builds by hand.**~~
+
+  The value comes from Hono's `secureHeaders()` today, so it is not attacker-controlled — but this is the one
+  raw attribute write on a path React is not escaping for us, and the framework does not own where the value
+  comes from.
+
+  **Fix:** validate against `/^[A-Za-z0-9+/=_-]+$/`; drop the attribute otherwise.
+
+  _Done as described,_ that exact character set — base64 and base64url, which is what any generator of a nonce
+  emits. Checked at the raw write rather than at `cspNonce`, so the guard travels with the injector rather
+  than with one of its callers. Dropped rather than escaped: a value that is not a nonce is not one, and a
+  page whose payload scripts the policy then refuses is the visible failure to have, where an escaped garbage
+  nonce would be a silent one. Five injection-shaped values are in the unit suite beside the base64url case.
+
+### ~~2.6 — No default cap on the bodies the framework's own action path buffers~~ — ✅ resolved in `07f3550`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:314` (`await request.text()`), `:335` (`await request.formData()`).**~~
+
+  Every `'use server'` export is a public POST endpoint by design; without `bodyLimit()` those two calls buffer
+  whatever arrives. `src/builder/rspack-config.ts:126` warns only when `src/server.ts` is **absent** — an app
+  that has one but never registered `bodyLimit()` is warned about nothing.
+
+  **Fix:** either apply a generous framework default on the action/form-post path only (overridable, and
+  documented as a floor the way the baseline headers are), or widen the build warning to detect a
+  `src/server.ts` with no `bodyLimit` and say so.
+
+  _The second, deliberately._ The first was rejected on two counts. There is no "only if unset" signal to read
+  the way the baseline headers have one, so a framework cap would be a **ceiling, not a floor**: an app
+  uploading a file through a server action could not raise it, and the escape hatch would have to be a new
+  config field — API surface, freezing at 1.0, in the one file whose doc comment says it "holds only what the
+  _build_ decides. Per-request concerns — CSRF, CSP, the body cap — are Hono middleware in `src/server.ts`."
+  That sentence is the framework's position on this, and `configuration.md` states it to users as "the
+  framework runs no CSRF check, body cap or CSP of its own".
+
+  So the warning is what changed. `mentions(srcDir, 'bodyLimit')` scans the whole of `src/` rather than
+  `src/server.ts` alone, so a cap registered from a helper module counts, and the message names what it looked
+  for so an unwarranted warning explains itself. Textual on purpose — the question is whether the author
+  thought about this at all, and the worst a wrong answer does is print something nobody needed. Four cases in
+  the unit suite: no `src/server.ts`, one without the cap, one that registers it from a helper, and the
+  testbed. `docs/pages.md`'s "Every action is a public endpoint" now says the body is buffered before the
+  action runs and points at the cap.
+
+### ~~2.7 — Write down that client-initiated actions rely on the CORS preflight~~ — ✅ resolved in `e3b181c`
+
+- [x] ~~**`refusesCrossSiteForm` is applied only to the `form-action` branch; the `rsc-action` branch
+      (`src/runtime/entry.rsc.tsx:307-327`) has no same-origin check at all.**~~
+
+  It does not need one — `x-rsc-action` is not a CORS-safelisted header, so a cross-origin POST cannot be sent
+  without a successful preflight _[measured: a cross-site `x-rsc-action` POST reaches the unknown-action-id 400
+  at `:311`, i.e. it passes no CSRF gate of its own]_. That is the standard defence and it is correct — but it
+  is load-bearing and written down nowhere outside the `refusesCrossSiteForm` doc comment.
+
+  **Fix:** add it to `SECURITY.md` beside the form-post rule, and pin the branch selection with the
+  `parseRenderRequest` tests from **6.1**.
+
+  _Done as described,_ and **6.1** is done with it. `SECURITY.md` says it beside the form-post rule, including
+  what an app gives up by adding a `cors()` permissive enough to allow `x-rsc-action`; the header's own
+  declaration in `request.ts` says the branch choice is a security boundary rather than a dispatch detail.
+  `parseRenderRequest` is now table-driven over method × `x-rsc-action` × content-type × `RSC`, with
+  `createRscRequest` round-tripped through it, and each case names the branch it lands on. One thing the table
+  turned up: the form content-type match is a **prefix** match, so `application/x-www-form-urlencodedX` is a
+  `form-action` — deliberate, since `; charset=UTF-8` has to stay in the branch, and erring wide is the safe
+  direction here: an over-matched POST lands on the guarded branch and decodes to nothing, where an
+  under-matched one would land on a branch with no origin check.
+
+---
+
+## 3. Correctness bugs
+
+### ~~3.1 — `PORT=""` binds a random port instead of the default~~ — ✅ resolved in `f71f16a`
+
+- [x] ~~**`src/cli/index.ts:61` tests `process.env.PORT ?` (falsy → treated as unset, so `PORT` is left in the
+      environment untouched); `src/deploy/node/runtime.ts:18` tests `process.env.PORT !== undefined` (empty
+      string → `Number('')` → **0** → "any free port"). The two disagree. [measured, against a real
+      `rshono start`]**~~
+
+  ```
+  PORT unset  -> serving on http://localhost:3000
+  PORT=""     -> serving on http://localhost:64659    <-- CLI says "unset", bundle says "port 0"
+  PORT="0"    -> serving on http://localhost:64660    (intended)
+  PORT="abc"  -> exit 1: RangeError [ERR_SOCKET_BAD_PORT] … Received type number (NaN)
+                         at Object.serveApp (webpack://…)
+  ```
+
+  **Why it matters:** an empty `PORT` is common in CI and container templates, and the failure is **silent**:
+  the process starts, reports success, and binds a port nothing will connect to.
+
+  **A second, smaller half:** the CLI validates `--port` with a clean `rshono: invalid --port "…"`
+  (`src/cli/index.ts:55-59`) but leaves `PORT` unvalidated and never range-checks either source, so these fall
+  through to Node as raw errors with a `webpack://` frame in the stack:
+
+  ```
+  PORT=abc rshono start           -> RangeError [ERR_SOCKET_BAD_PORT] … Received type number (NaN)  + stack
+  rshono start --port 999999      -> RangeError [ERR_SOCKET_BAD_PORT] … Received number (999999)    + stack
+  HOST=bogus.invalid rshono start -> Error: getaddrinfo ENOTFOUND bogus.invalid (unhandled 'error') + stack
+  ```
+
+  **Fix:** validate both sources through one helper (integer, 0–65535) in the CLI, report them the way the
+  `--port` flag already is, and make the two "is it set" tests agree.
+
+  _Done as described,_ with the helper in `src/server/server-config.ts` beside the `SERVER_DEFAULTS` it falls
+  back to — not in the CLI — because the CLI is only one of the two readers: a bundle started as
+  `node dist/server/main.mjs` reads `PORT` itself, and a helper the CLI owned would have left that half free to
+  drift again. Blank is "unset" on both sides, an explicit `PORT=0` still means "any free port", and everything
+  else present must be digits in 0–65535 — digits, because `Number` alone accepts `0x50`, `1e3`, `+80` and
+  `3.0` as ports nobody typed. The node runtime parses **under** the `??`, so the dev server's own port
+  override still wins without the environment being read at all.
+
+  The `HOST=bogus.invalid` line above is left as it is: a hostname is only wrong once DNS says so, and the
+  clean report for that belongs with the listener rather than with an input parse.
+
+  **6.12** is done with it: `parsePort` is table-driven in the unit suite, and `start.test.mjs` covers the CLI
+  half — an empty `PORT` passed on untouched for the bundle to read as unset, a valid one and `--port` through
+  with the flag winning, and `abc` / `999999` from either source refused with one line and no stack, before the
+  bundle runs.
+
+### ~~3.2 — An action request that fails before its payload is produced makes the browser throw a `TypeError`~~ — ✅ resolved in `ae127b0`
+
+- [x] ~~**`src/runtime/entry.client.tsx:377` reads `payload.returnValue!`; `:366` feeds every action response
+      straight to `createFromFetch` with no status or content-type check.**~~
+
+  Two distinct shapes reach application code as a meaningless error:
+
+  **(a) A non-flight response body.** `createFromFetch` is handed the body whatever the status. Feeding the
+  parser a plain-text body directly _[measured]_:
+
+  ```
+  createFromReadableStream(<<"Payload Too Large">>)     -> throws Error: Connection closed.
+  createFromReadableStream(<<"Internal Server Error">>) -> throws Error: Connection closed.
+  ```
+
+  So an action POST rejected by `bodyLimit()` with a 413 — which `test/prod-config.test.mjs:144-170` proves is
+  reachable — surfaces as "Connection closed." with the real status nowhere in sight.
+
+  **(b) A flight payload with no `returnValue`.** When something throws _before_ the payload is produced on an
+  `rsc-action` request, `app.onError` renders the app's `error` page as flight (`entry.rsc.tsx:510`) **without**
+  forwarding `returnValue`. The client then reads `.ok` off `undefined` at `:377` and the caller sees
+  `Cannot read properties of undefined` — for an action that may already have run. The triggers are
+  `loadPage()` failing (a chunk gone after a deploy) or `decodeReply` on an undecodable body.
+
+  > Note: a **render** error is _not_ a trigger. `renderComponent` returns the stream at `entry.rsc.tsx:256`
+  > before the render can throw, so the response is already committed. An earlier draft of this review claimed
+  > otherwise; corrected here.
+
+  **Fix:** check `response.ok` and the content type before decoding; carry `returnValue` through the error
+  render; drop the `!` and make the client tolerate its absence with a real message.
+
+  _Done, with one deliberate departure:_ the gate is the **content type alone**, not `response.ok`. A payload
+  legitimately arrives as a 404 from the `notFound` page and as a 500 from an action that threw — both carry a
+  real payload the caller has to see — so a status gate would have refused the two responses the runtime most
+  needs to decode. `payloadResponse` reads the body of what it refuses (bounded to 200 characters) into the
+  message, because a plain-text refusal says what it refused only in its body and HTTP/2 carries no
+  `statusText` at all. Soft navigation goes through the same helper: it still ends in a reload, but the console
+  now says why instead of "Connection closed."
+
+  For (b), the result is carried across in `actionResults` — a `WeakMap` keyed on the Hono context, the way
+  `beginPageRender` keys its own marker, so nothing is added to the payload type or to `ctx` and nothing
+  outlives its request. `onError` passes it to the `error`-page render, so an action that ran gets its value
+  back even though the page it returned to could not be built. Where nothing ran there is nothing to carry and
+  the client says so.
+
+  **6.13** is done with it. The trigger needed a page that fails _after_ the action —
+  `apps/testbed/src/components/unloadable.tsx`, a module that throws as it evaluates, which is what a chunk
+  that went missing between deploys looks like from the runtime's side. `prod.test.mjs` posts an action to it
+  (the result comes back with the error page's payload) and posts an undecodable body to `/users` (no result is
+  invented). The non-flight half is a browser test, since the client runtime is what changed: an action POST
+  fulfilled as a 413 must surface the status rather than the parser's error.
+
+### ~~3.3 — A `notFound` or `error` page that itself throws a control signal produces a bodiless, unlogged 500~~ — ✅ resolved in `bd62257`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:491` re-enters `respondToControlSignal` from `onError` with no guard.**~~
+
+  Trace: `onError(error)` → `isControlSignal` → `respondToControlSignal` (`:409-424`) → `renderComponent(the
+notFound page)` → that page throws `redirect()`/`notFound()` → the signal propagates **out of `onError`**.
+  Verified that a throwing `onError` **rejects `app.fetch`** in Hono (`compose.js` calls
+  `res = await onError(err, context)` inside the `catch`, unguarded). `@hono/node-server` then hits
+  `handleFetchError`, which is `new Response(null, { status: 500 })` — no body, and **nothing written to the
+  log**.
+
+  > Scope note: the `error`-page path at `:509-513` _does_ have a try/catch and _does_ report through
+  > `reportServerError` before falling back to the plain-text 500 at `:516`. It is the control-signal path at
+  > `:491` — and the same re-entry from the page handler at `:459` — that is unguarded. An earlier draft
+  > described both as unlogged; only this one is.
+
+  **Fix:** a one-shot guard so a second signal degrades to `plainNotFound` / the framework 500 rather than
+  escaping.
+
+  _Done, as a try/catch around the `notFound`-page render itself_ rather than as a re-entry counter. It is the
+  same shape the `error`-page path at `:509-513` already uses, it covers both callers at once (the handler
+  catch as well as `onError`), and it catches an **ordinary** throw from that page too — which had the same
+  hole and was not in the original finding. The degraded answer is `plainNotFound`: the request still gets the
+  404 it earned, and `reportServerError` names the page that failed, so the log is no longer silent.
+  Terminating by construction — the page is rendered once and what replaces it cannot fail.
+
+  One case is **not** degraded: a `redirect()` from the `notFound` page. Nothing is committed when that signal
+  arrives, the redirect branch cannot fail, and `app.notFound` has always answered it as a real 3xx — so
+  degrading it here would have made the same page behave differently depending on which of the two paths
+  rendered it. It recurses exactly once.
+
+  Covered in `prod.test.mjs` from both entries (an unmatched path, and a page that called `notFound()`), for
+  the thrown signal and for the redirect; the testbed's 404 page fails on demand behind `?boom=`, which
+  nothing links to. Verified that the first pair answers **500** without the fix.
+
+### ~~3.4 — `redirect()` raised after the SSR shell has flushed never becomes a real 3xx~~ — ✅ resolved in `4f4ae3e`
+
+- [x] **`renderComponent` consults `controlSignal` exactly once, after `await renderHTML(...)` returns
+      (`src/runtime/entry.rsc.tsx:277`). `renderHTML` returns at _shell ready_, so a signal thrown from inside a
+      `<Suspense>` that resolves later loses the race and the response is already committed as
+      `200 text/html`. [measured]**
+
+  Reproduced on a throwaway minimal-app route whose `<Suspense>` child awaits 400 ms and then calls
+  `redirect('/login-target')`:
+
+  ```
+  GET /slow-redirect  ->  200 text/html   (expected 303)
+  body: …<p data-section="loading">Loading…</p>…
+        …push("3:E{\"digest\":\"RSHONO_REDIRECT;303;%2Flogin-target\"}")…$RX("B:0")…</body></html>
+  ```
+
+  The code at `:277-292` handles the _near_ race deliberately and well (its comment describes a boundary
+  settling "just before the shell was ready"); this is the case past that window.
+
+  **Why it matters:** the document closes cleanly and React marks the boundary errored, so **a client with
+  JavaScript should recover** — the digest reaches `hydrateRoot`'s `onUncaughtError`
+  (`entry.client.tsx:394-395`) → `handleControlDigest(…, {hard: true})` → `location.assign()`. That half is
+  _[by construction]_: it needs the browser suite to confirm, and note that `onRecoverableError` is **not**
+  wired up _[measured: only `onCaughtError` and `onUncaughtError` are]_, so it depends on React classifying
+  this as uncaught rather than recoverable. **Without JavaScript the user is left on the Suspense fallback
+  under a `200`.** `notFound()` degrades identically _[by construction]_ — same signal, same single check —
+  which makes it a soft 404 that crawlers will index.
+
+  **The existing test asserts a guarantee the framework does not have.** `test/prod.test.mjs:141`
+  ("redirect() from inside a bare Suspense, after the shell has already resolved") passes only because the
+  testbed's section awaits `Promise.resolve()` and wins the race.
+
+  #### Decision: accept the degradation, stop paying for it, and warn at authoring time
+
+  **A real 3xx is not recoverable here.** By the time the signal fires, the status line, the headers and the
+  shell bytes are on the wire — `renderHTML` returns at shell-ready (`entry.ssr.tsx:102`) and that stream is
+  already handed to `c.body(...)` (`entry.rsc.tsx:293`). HTTP has no take-backs once the head is committed, so
+  the only option that yields a genuine 3xx is to not stream at all. Costed:
+
+  | Option                      | Happy-path cost                                                      | Redirect-path cost  | No-JS                       |
+  | --------------------------- | -------------------------------------------------------------------- | ------------------- | --------------------------- |
+  | Status quo                  | zero                                                                 | full render, wasted | stranded on fallback, `200` |
+  | Buffer until `allReady`     | **TTFB = full render time, whole document in memory, every request** | correct 3xx         | correct 3xx                 |
+  | **Abort on late signal** ✅ | one boolean check                                                    | winds down early    | stranded (unchanged)        |
+
+  Buffering is rejected: it taxes 100% of page renders to fix a case that fires on a vanishing fraction of
+  them, and it deletes streaming SSR — most of why this architecture exists.
+
+  **What is actually wasted today** is the render itself. `controlSignal` is read once at `:277` and never
+  again, so every remaining boundary renders, its data settles, and the whole flight payload is serialized and
+  injected — for a page the client discards at `location.assign()`. Per
+  [4.1](#41--neither-half-of-the-flight-injector-honours-backpressure) there is no backpressure, so for a slow
+  client that doomed document also accumulates in memory.
+
+  - [x] **(a) Abort the doomed render.** The wind-down already exists for the _pre_-shell race at `:286-290`;
+        this adds the post-shell arm:
+
+        ```js
+                    let controlSignal;
+                    let shellFlushed = false;               // set right after `await renderHTML(...)` returns
+
+                    const rscStream = renderToReadableStream(rscPayload, {
+                      signal,
+                      onError(error) {
+                        if (isControlSignal(error)) {
+                          controlSignal = error;
+                          // Post-shell: the response is committed and the digest is the only path left. Everything
+                          // still rendering is for a page the client will navigate away from.
+                          if (shellFlushed) setImmediate(() => renderAbort.abort(error));
+                          return error.digest;
+                        }
+                        …
+                      },
+                    });
+                    ```
+
+                    Near-free on the happy path; on the redirect path it stops the remaining boundaries, lets
+                    `flight-inject`'s `cancel`/`flush` run, and fires the `release()` at `:216` that today only fires when
+                    the doomed render finishes on its own.
+
+                    Aborting does **not** truncate the client's recovery path: `react-dom`'s abort converts pending
+                    boundaries into `$RX` client-render instructions and closes the document cleanly — the shape the client
+                    runtime already handles.
+
+  - [x] **(b) ⚠️ The `setImmediate` is load-bearing — this is what the test must pin.** Aborting
+        _synchronously_ inside `onError` would cut React off **before** it writes the error row carrying the
+        digest, destroying the only recovery the client has. Deferring one macrotask lets the current flush
+        complete; it is the same boundary `flight-inject` already uses (`src/runtime/flight-inject.ts:33`).
+        _This timing was reasoned about, not measured_ — a test must assert that the digest survives the abort,
+        not merely that a redirect eventually happens.
+
+        _Measured while implementing, and the premise does not hold today:_ with the abort called
+            **synchronously** from inside `onError`, the digest row still reaches the client — `3:E{"digest":
+            "RSHONO_REDIRECT;303;%2Flogin"}` is written, `$RX("B:0")` follows, and the document closes cleanly, on
+            react-server-dom-rspack 0.1.0 / React 19.2.8. So the deferral is **defensive, not load-bearing**: it is
+            kept because that ordering is a React internal the `^19.1.0` peer range does not promise, and one
+            macrotask on an already-doomed render costs nothing. The test asserts the digest either way, which is
+            the contract worth pinning; it cannot distinguish the two implementations, and the note above is
+            corrected rather than dropped so nobody re-derives the original claim.
+
+  - [x] **(c) Dev-only warning.** `isDev` is a DefinePlugin constant (`entry.rsc.tsx:43`), so the block is
+        dead-code-eliminated in production. A loud `[rshono]` warning when a control signal arrives post-shell
+        gives authoring-time discovery at zero runtime cost — which is worth more than a docs paragraph,
+        because the root fix is an app-code fix.
+
+        _Done — and the DCE claim is wrong, checked against the built bundle:_ `isDev` is destructured out of
+            `__RSHONO_CONFIG__`, and the minifier does not fold that through, so the warning's string ships in
+            `dist/server/main.mjs` (~700 bytes) and costs one boolean check per control signal. It never *fires* in
+            production, which is what `prod.test.mjs` now asserts, and `dev.test.mjs` asserts that it does in dev —
+            naming the call, the request and where the decision belongs. Left as it is: the same pattern is used
+            for every other `isDev` branch in the file, and making this one call site special would be the
+            inconsistency, not the fix.
+
+  - [x] **(d) Document the limitation and the correct pattern.** Under "Requirements & limitations": a
+        `redirect()` / `notFound()` from a boundary that resolves after the shell cannot produce a 3xx, and
+        without JavaScript the visitor stays on the fallback under a `200`. The fix is app-side — an auth gate
+        belongs in middleware or the page component body, **before** the render commits to streaming. Note that
+        `notFound()` degrades to a soft 404 that crawlers will index.
+
+  - [x] **(e) Replace the test that passes for the wrong reason** (`test/prod.test.mjs:141`) with one whose
+        `<Suspense>` child genuinely loses the race, for both `redirect()` and `notFound()`.
+
+        _Its claim was replaced rather than the test:_ what it actually pins — a signal that settles just
+            before shell-ready is still a real 3xx — is real behaviour worth keeping, so it was renamed and
+            re-commented to say which window it covers. The new pair drives `/late-signal`, whose section waits
+            50ms and whose neighbour takes 2s, and asserts the digest, the `$RX` instructions, the clean document
+            trailer, the fallback a no-JS visitor is left on, and — through the neighbour — that the doomed render
+            was actually wound down. Verified both fail without (a): the slow section renders and the response
+            waits it out.
+
+  > Rejected: `<meta http-equiv="refresh">` as a no-JS escape hatch. It creates a history entry, so Back
+  > returns to the redirecting page and redirects again — a trap.
+
+  > Scope: the abort is the **document** path only. A flight fetch commits its response the moment
+  > `renderComponent` returns the stream, so there is no shell race there and the digest riding the payload is
+  > already the documented answer (`/suspense-redirect` with `RSC: 1`). The same wasted-render argument applies
+  > to it, but at a fraction of the cost and with a live client tree on the other end, so it was left alone
+  > rather than folded into a decision that was taken about the SSR half.
+
+### ~~3.5 — A `HEAD` on a page route renders the page and throws the result away~~ — ✅ resolved in `a9da318`
+
+- [x] **[measured, against a real build]** `HEAD /` → `200`, `content-type: text/html;charset=utf-8`,
+      `cache-control: private, no-cache`, `vary: RSC`, **0 bytes**, no `Content-Length`. Those headers come from
+      the real render, so the shell was produced.
+
+  Hono wraps the `GET` response as `new Response(null, res)`, so the body stream is never consumed:
+  `flush`/`cancel` in `src/runtime/flight-inject.ts` never run, and the `release()` at
+  `src/runtime/entry.rsc.tsx:216` never fires — leaving the abort forwarder attached to the request signal
+  until the request object is collected.
+
+  **Why it matters:** retention is bounded, but the work is pure waste and a `HEAD` flood is a cheap amplifier.
+
+  **Fix:** answer `HEAD` from the head only, or cancel the stream and release.
+
+  _Both, split by route kind._ A `render: 'static'` route takes the prerendered path for a HEAD as well as a
+  GET, so it reads a file instead of rendering a page — and that turned out to fix a second thing: a rendered
+  answer carries no `ETag`, so a conditional HEAD on a prerendered route could never 304, and the
+  `cache-control` it reported was `private, no-cache` rather than the `public, max-age=300` its own GET sends.
+  Everything else keeps rendering, because "answer from the head only" would have to invent a status: a page
+  can 404, redirect or 500, and a HEAD that says 200 for a page whose GET redirects is worse than a wasted
+  render. What changed there is that the body is **cancelled** rather than dropped, which is what ends the
+  render and fires `release()`.
+
+  **6.7** is done with it — the suite had no HEAD on a page route at all. It now asserts every header a HEAD
+  and its GET must agree on (`content-type`, `cache-control`, `vary`, `etag`, `content-length`), the empty
+  body, and a conditional HEAD that 304s off the ETag it was just given. Verified both fail without the fix.
+
+### ~~3.6 — Any method other than `GET`/`POST` on a page route is a 404, not a 405~~ — ✅ resolved in `9c045b6`
+
+- [x] **`src/runtime/entry.rsc.tsx:463` registers `app.on(['GET', 'POST'], …)`, leaving every other method to
+      the not-found handler. [measured]**
+
+  ```
+  GET /page -> 200    POST /page -> 200    HEAD /page -> 200 (empty body)
+  PUT /page -> 404    DELETE /page -> 404  OPTIONS /page -> 404
+  ```
+
+  `405` with an `Allow: GET, POST, HEAD` header is the more correct answer. Implementing it means tracking the
+  methods registered per path, so it is a real change rather than a one-liner — 404 is defensible as a
+  documented choice, but right now it is an accident.
+
+  #### Decision: keep the 404, make it a documented choice
+
+  `HEAD` already resolves correctly through the `GET` route ([3.5](#35--a-head-on-a-page-route-renders-the-page-and-throws-the-result-away)),
+  so the only shapes affected are `PUT` / `PATCH` / `DELETE` / `OPTIONS` on a _page_ — none of which a page
+  route is ever meant to answer. The per-path method registry that 405 requires is real work and new state on
+  a hot path, bought for a distinction no client acts on differently here.
+
+  - [x] Add the sentence to "Requirements & limitations": page routes answer `GET`, `POST` and `HEAD`;
+        every other method is a 404 rather than a 405, and an endpoint route is the way to answer one.
+
+        _Done, in the README and beside the endpoint-route rules in `docs/routing.md` — which is where the way
+            out belongs, since `method` defaults to `all` there. Pinned in `prod.test.mjs` as well: PUT, PATCH,
+            DELETE and OPTIONS all 404 with no `Allow` header, and the endpoint route answers the OPTIONS a page
+            will not. Those requests carry the app's own `Origin`, because the testbed's `csrf()` refuses an
+            unsafe method with a foreign one before the router is reached — a 403 that says nothing about routing._
+
+  - [ ] Revisit only if a real need appears (a `PUT`-based API mistakenly pointed at a page path is the
+        plausible one). Adding `Allow` later is not a breaking change.
+
+### ~~3.7 — `render: 'static'` routes the build skipped still take the prerendered lookup on every request~~ — ✅ resolved in `b1e8d8c`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:429` computes `servesPrerendered` from `route.render === 'static'` alone.**~~
+
+  The build's `skipped` list (`src/server/ssg.ts:140-141,150-152`) never reaches the runtime, and misses are
+  deliberately **not** cached (`src/server/ssg.ts:64-68` — caching misses would let anyone mint entries), so it
+  never warms up. A parameterised static route does a failed `readFile` for **every** param value that was not
+  prerendered, forever — including every value affected by the encoding bug in [1.2](#12--blocker-prerendered-pages-whose-params-need-percent-encoding-are-built-and-then-never-served).
+
+  **Fix:** record the prerendered paths in the build marker and gate the lookup on it.
+
+  _Done, with the record in the store rather than in the build marker._ The marker is `rshono start`'s — the
+  CLI reads it to refuse a build for another platform — and it does not travel into the asset store a
+  target without a filesystem reads. `dist/ssg/manifest.json` does: it is written by the same pass that
+  writes the pages, and Cloudflare's `finalize` already copies that whole directory into the assets tree.
+
+  Keyed by `ssgFilePath`, not by request path — that function is the one canonical form both sides already
+  share, so the index cannot disagree with the store about encoding the way the two sides once did about
+  `café` ([1.2](#12--blocker-prerendered-pages-whose-params-need-percent-encoding-are-built-and-then-never-served)).
+  Both readers gate on it: filesystem targets read it once per process, Workers fetch it once per isolate —
+  worth a subrequest there, since it saves one on every miss. A missing or unparseable manifest reads as "no
+  index", which gates nothing, so an older build behaves exactly as it did.
+
+  `servesPrerendered` itself is unchanged: the gate sits one level down, in each runtime's
+  `readPrerendered`, which is the only place that knows how its store is addressed. What is saved is the
+  store access, not the branch.
+
+  Covered in the unit suite (a file the manifest does not list is not served; no manifest still serves; a
+  broken one does not take the store down) and on Workers by counting binding calls — a path the build never
+  prerendered costs no page read at all.
+
+### ~~3.8 — A plain-text 404 carries no `Cache-Control`~~ — ✅ resolved in `11d2a69`
+
+- [x] ~~**`plainNotFound` (`src/runtime/entry.rsc.tsx:138-140`) is `text/plain`, so it misses the
+      `PAGE_CONTENT_TYPE` gate at `:390` that adds `private, no-cache` at `:394`. [measured]**~~
+
+  ```
+  404  content-type: text/plain  vary: RSC  x-content-type-options: nosniff  …  (no cache-control)
+  ```
+
+  Verified `cc=null` on `PUT /`, `DELETE /`, and on `GET /nope` for an app with no `notFound` page.
+
+  **Why it matters:** a 404 is heuristically cacheable per RFC 9111, so a shared cache may store it — while the
+  _rendered_ HTML 404 next to it is correctly `private, no-cache`. The common case (a page that throws during
+  render) returns the framework's `failureDocument` as `text/html` and _does_ get the default _[measured]_, so
+  this is the uncommon path silently behaving differently.
+
+  **Fix:** set it explicitly in `plainNotFound`. (The plain-text 500 at `:516` has the same gap, but 500 is not
+  in the heuristic list, so that half is consistency only.)
+
+  _Done as described, both halves,_ with the value pulled into a `PAGE_CACHE_CONTROL` constant so the three
+  places that name it cannot drift. Asserted where the framework's own answers are actually reachable — the
+  minimal app, which has neither page — and in `prod.test.mjs` against the _rendered_ 404 beside it rather
+  than against a literal, since the point is that one request answered two ways must not promise two things.
+
+### ~~3.9 — Wildcard / regex / optional params plus `staticPaths` fail the whole build with a raw error~~ — ✅ resolved in `8eba15f`
+
+- [x] **`src/server/ssg.ts:43,49` throw out of `interpolatePath`, which nothing catches (`:144` →
+      `buildCommand` → `main().catch` → `process.exit(1)`), and neither message carries the `[rshono]` prefix
+      every other framework error uses.**
+
+  Every _other_ unprerenderable route gets `⚠ … will SSR per request` and is pushed to `skipped`
+  (`src/server/ssg.ts:140-141`). This one kills the build.
+
+  **Fix:** catch per route, warn, skip — matching the behaviour one branch above it.
+
+  _Done as described,_ over the whole of `await staticPaths()` rather than the interpolation alone: a
+  `staticPaths` that **rejects** — a database that blipped mid-build — leaves the route exactly as
+  unprerenderable, and killing the build over it is the same wrong trade.
+
+  The messages became reasons rather than sentences, since the caller writes the line and already names the
+  route, which is also what settles the missing `[rshono]` prefix — a warning in the `⚠` house style, like
+  every one beside it:
+
+  ```
+  ⚠ Static route "/files/*" will SSR per request — wildcard segments are not supported by staticPaths.
+  ⚠ Static route "/docs/:slug" will SSR per request — staticPaths returned a param set without "slug".
+  ```
+
+  **Deliberately still fatal**, one branch down: a `staticPaths` _value_ no single file can hold (`a b/c`,
+  `a:b`, `..`). The distinction is route shape versus a named page — a shape nothing could prerender is the
+  framework's business to route around, while a value the author asked for by name and the store cannot answer
+  is theirs to see. Its own test keeps asserting the rejection.
+
+### ~~3.10 — _(nit)_ A soft navigation to an unmatched path gets a payload without `notFound: true`~~ — ✅ resolved in `4610a7d`
+
+- [x] ~~**`src/runtime/entry.rsc.tsx:484` omits the flag that `:421` sets.**~~
+
+  No functional impact today — only `setServerCallback` reads it (`entry.client.tsx:376`) — but it is an
+  inconsistency in the wire contract, and the kind that costs an afternoon later.
+
+  **Fix:** pass `notFound: true` in both places.
+
+  _Done as described._ Writing the test turned up something worth recording: a `notFound()` thrown from
+  inside a **component** on a flight request never reaches either of those places. `renderComponent` hands
+  the payload stream back before the render can throw (`entry.rsc.tsx:256`), so the response is committed and
+  the signal rides the payload as a digest — `GET /profile/9999` with `RSC: 1` is a **200** carrying
+  `RSHONO_NOT_FOUND`, which the client runtime turns into a real load. Same signal, same page, two ways of
+  getting there; the suite now pins both, because they look interchangeable and are not.
+
+---
+
+## 4. Robustness and performance
+
+### ~~4.1 — Neither half of the flight injector honours backpressure~~ — ✅ resolved in `5aa6611`
+
+- [x] ~~**`src/runtime/flight-inject.ts:156-179` (`transform`) returns as soon as it has pushed to `batch`, so
+      `pipeThrough` never backpressures React's HTML stream; `writeFlight` (`:122-154`) pumps the whole RSC
+      stream into the controller from a detached promise (`:174`). Nothing consults
+      `controller.desiredSize`.**~~
+
+  A slow client therefore accumulates the whole document plus the whole payload in the process. Bounded by page
+  size, so not a live incident — but it is the shape of a memory-pressure bug under load, and worth a
+  deliberate decision before 1.0 rather than after.
+
+  **Decided: real backpressure, from a pull-driven wrapper.** Measured first, because half the finding did not
+  hold. The **payload** half did: a consumer that read one chunk and stalled still took all 500 chunks of a
+  test payload into the readable's queue. The **HTML** half mostly did not — a deferred `emitBatch` still sets
+  the transform's backpressure, so a React-shaped source (flushes separated by a macrotask) parked after 7
+  chunks; only a producer that never yields the microtask queue was admitted in full.
+
+  `controller.desiredSize` could not have fixed either: a transform readable's high-water mark is 0, so it is
+  never positive, and `Transformer` has no "the consumer wants more" hook. `injectFlightPayload` therefore
+  returns a `ReadableWritablePair` whose readable is a pull-driven wrapper around the transform; `pull` runs
+  once per chunk the consumer takes and releases one permit, and both producers take one before they enqueue.
+  Same payload, same stalled consumer: **3 chunks instead of 500**, and reading resumes it. The permit is per
+  _batch_, not per chunk, because a React flush has to leave as one chunk — so what stays buffered is one
+  flush, which is the bound React itself holds while building one.
+
+  **The cost, measured** (`91d4af8`): 3.6ms → 4.0ms to push a 187 kB page (400 HTML chunks, 400 payload
+  chunks) through the module with nothing else in the way — one extra stream hop and a microtask per chunk.
+  Not the shape of a real response, where the socket write dominates by orders of magnitude, and the trade is
+  a bounded process against an 11% slower in-memory pipeline.
+
+  Two side effects worth recording. The wrapper's `cancel` is the one notification the standard never skips,
+  where the transformer's own is skipped for the whole window `flush` spends awaiting the payload — so the
+  teardown that releases the RSC branch and fires `onDone` now hangs off the reliable one, and is idempotent
+  because both can reach it. And the two enqueues in `flush` are deliberately left ungated: the response is
+  over by then, and parking its last two chunks would only add a way for it not to end.
+
+### ~~4.2 — `injectFlightPayload` has no guard for a document trailer straddling two batches~~ — ✅ resolved in `0ea397c`
+
+- [x] **`emitBatch` tests for `</body></html>` on the joined batch only (`src/runtime/flight-inject.ts:118`);
+      no tail is carried across batches. [measured]** Feeding it `</bo` and `dy></html>` separated by a real
+      macrotask:
+
+  ```
+  <html><body><p>hi</p></bo<script>(self.__FLIGHT_DATA||=[]).push("0:\"hi\"\n")</script>dy></html></body></html>
+  ```
+
+  The flight `<script>` is injected **inside the `</body>` tag** and the trailer appears twice.
+
+  **Status: defence-in-depth, not a live bug.** The module's own comment at `:97-99` states the assumption
+  explicitly — _"React writes its final flush in one synchronous run, so a trailer split across batches is not
+  a shape it produces"_ — and that is correct today. But this injector exists **because** `rsc-html-stream`
+  made a narrower version of the same assumption and got it wrong (see the module header at `:6-8`), so the
+  assumption deserves a guard rather than a comment.
+
+  The five existing split tests cannot catch it: they enqueue synchronously, so every split lands in one batch.
+
+  **Fix:** carry a `TRAILER_BYTES.length - 1` byte tail across batches; add a macrotask-separated test.
+
+  _Done as described,_ with the tail chosen rather than fixed: `emitBatch` holds back the longest suffix of the
+  batch that is a prefix of the trailer — 14 bytes at most and **0 in practice**, since a React flush ends
+  with a closed tag rather than the start of one, so no intermediate flush pays for the guard. `flush` is the
+  one call allowed to emit such a tail, because by then there is no next batch to complete it.
+
+  Two consequences worth recording. A false trailer mid-document is no longer silently dropped — it only
+  leaves the carry if nothing completes it, which is strictly better than the old unconditional drop. And a
+  tail that never completes leaves **after** the payload scripts rather than before them: releasing it the
+  moment a script wants to go out is the very bug being guarded, since the next batch may be the rest of the
+  trailer. That costs at most 13 bytes of a truncated document arriving late, still inside `<body>`, and only
+  a truncated document can reach it. Both halves are pinned by the new macrotask-separated test.
+
+### ~~4.3 — `prerenderStaticRoutes` renders sequentially and does not deduplicate~~ — ✅ resolved in `33da990`
+
+- [x] ~~**`src/server/ssg.ts:134-173` awaits each path in turn and renders each twice (document at `:148`, then
+      flight at `:164`).**~~
+
+  A documentation site with a few hundred `staticPaths` entries pays all of that serially, and a duplicate
+  entry is rendered and written twice with no warning.
+
+  **Fix:** bounded-concurrency map over paths; de-duplicate the interpolated path list before rendering.
+
+  _Done as described._ The pass is now two: expand the routes into a de-duplicated target list, then render
+  that list through a worker pool of **8** — a pool rather than fixed batches, since a batch is only as fast
+  as its slowest member. The app's own handler serves these renders, so the concurrency is the concurrency a
+  request already gets in production. The two renders _per_ path stay sequential: the flight payload is only
+  worth asking for once the document came back 200.
+
+  Three things moved so that a concurrent pass stays as legible as a serial one. `written`, `skipped` and the
+  manifest are folded back in **target order** rather than completion order; each path's warnings are buffered
+  and printed with it, so the build log does not depend on which page finished first; and `ssgFilePath` is
+  resolved during expansion, so which of several unrepresentable paths fails the build does not depend on
+  render order either. A repeated path is warned about once per route with a count rather than once per
+  occurrence — it is usually a bug in the app's query, and a site with many duplicates should not get a wall
+  of them.
+
+---
+
+## 5. API surface — the parts that freeze at 1.0.0
+
+The public surface is three entry points and is the right size: `defineRoutes` / `defineConfig` plus types from
+`@rshono/core`; `getRequestContext` / `redirect` / `notFound` / `onServerError` / `publicUrl` from `/server`;
+`useNavigation` / `AsyncBoundary` / `CatchBoundary` from `/client`. Verified that `dist/index.js` pulls in no
+runtime machinery, as advertised. These are the items that cannot change after 1.0.0 without a major.
+
+- [x] ~~**5.1 — `onServerError` cannot reliably reach `waitUntil`, and reaches it inconsistently.**~~ — ✅ resolved in `02c6cd7`.
+      `ServerErrorHandler` is given `(error, { source, request })` and its return value is ignored
+      (`src/runtime/context.ts:555-563,607-621`), so on Workers and Lambda a report started there is cut off
+      when the response ends. There _is_ an undocumented workaround — `getRequestContext().hono.executionCtx` —
+      but it works for only three of the four sources: `render`, `ssr` and `action` are reported from inside
+      `runWithContext`, while `source: 'request'` is reported at `entry.rsc.tsx:500`, **outside** it, where
+      `getRequestContext()` throws. Reporting is the one thing this hook exists for.
+      → **Fix:** put the Hono `Context` (or a `waitUntil`) on `ServerErrorContext`. That also gives a handler
+      `c.var.requestId` to correlate on, which it cannot get today.
+
+      _Both, not either._ `hono` closes the reachability gap and carries `hono.var` / `hono.env`;
+          `waitUntil` is there because `c.executionCtx` **throws** where a platform has no execution context —
+          the `node`, `vercel` and `aws-lambda` targets, and dev — so a handler reaching for it itself would
+          have its report swallowed by the guard that keeps reporting from failing a request, on exactly the
+          platforms where nothing needed holding open. It is a no-op there instead, and its doc says so per
+          target, including that `hono/aws-lambda`'s `streamHandle` exposes no execution context to ask (verified
+          in `node_modules/hono`: it calls `app.fetch(req, env)` with no third argument), so a slow report on
+          Lambda is best-effort. Wrapping `streamifyResponse` to fix that was rejected — the marker it puts on
+          the handler is what makes Lambda stream at all, so holding the invocation open would mean
+          reimplementing the adapter.
+
+          `ServerErrorContext` and `ServerErrorHandler` became generic over the app's `Env`, defaulting so
+          nothing existing changes, matching `getRequestContext<E>`. `reportServerError` takes `hono` and
+          derives `request` from it, so the nine call sites did not grow. The testbed's reporter now uses both
+          for real, so the existing assertion on `[error-reporter] request /api/boom` — the source reported
+          outside the ambient context — proves both reach a handler.
+
+- [x] ~~**5.2 — `EndpointRoute.method` takes a single method.** `method?: HTTPMethod` (`src/router.ts:214`)
+      cannot express `['get', 'post']`, so a two-method endpoint has to be `'all'` plus a hand-rolled check.
+      Widening to `HTTPMethod | readonly HTTPMethod[]` is backward compatible, and much harder to add after
+      1.0. Settle alongside [1.3](#13--blocker-httpmethod-advertises-head-which-can-never-match).~~ — ✅
+      resolved in `21aef60`.
+
+      _Widened as described._ Registration de-duplicates the list, because `app.on(['GET', 'GET'], …)`
+          registers the path twice. Validation refuses the two lists that are mistakes rather than guessing:
+          an empty one, and one containing `'all'` — which is either the whole thing or a slip, and answering
+          every method quietly is exactly the shape `validate-entries.ts` exists to prevent. A bad *member* is
+          named rather than the array printed, so `['get', 'HEAD']` still gets the "use 'get'" advice.
+          `methodsOf` flattens a list the same way it expands `'all'`, so the shadowing check holds for both.
+          The testbed grew a real two-method endpoint, asserted over HTTP for both listed methods and two that
+          are not.
+
+- [x] ~~**5.3 — `staticPaths` is not typed against its own path.**~~ — ✅ resolved in `43993c0`. `src/router.ts:189` returns
+      `Array<Record<string, string>>`, so a typo in a param key is a build-time throw from `interpolatePath`
+      (`staticPaths for "…" returned a param set without "…"`, `src/server/ssg.ts:53`) rather than a type error.
+      `PathParams<P>` already exists. Using it here means either making `PageRoute` generic over `path` or
+      extending the `ValidateRoute` conditional that already captures `P` for the `component` check — worth
+      doing while the type is still free to move.
+
+      _The second one._ Making `PageRoute` generic would not have worked: the contextual type comes from the
+          `Route` constraint, so `staticPaths` would still be checked against `Record<string, string>`.
+          Extending `ValidateRoute` brands the `staticPaths` field the same way a props mismatch brands
+          `component`.
+
+          **Keys, not assignability** — that was the one real decision. `[Awaited<Sets>] extends
+          [ReadonlyArray<PathParams<P>>]` looked right and was wrong: `Record<string, string>` is not assignable
+          to `{ slug: string }`, so a `staticPaths` annotated as returning exactly the type the field declares
+          became a type error. Comparing `keyof PathParams<P>` against `keyof Set` accepts an index signature
+          (nothing to check, so the build stays the backstop) and still rejects a wrong or missing key. A
+          param-less path is skipped, since `staticPaths` is never called for one.
+
+          Verified both ways against the testbed: `{ wrong: 'a' }` and `{}` for `/docs/:slug` are errors naming
+          the path; an inferred `{ slug }`, extra keys beside it, a synchronous return and an explicit
+          `Record<string, string>` annotation all still compile.
+
+- [x] ~~**5.4 — `RequestContext` has eight throw-only stubs.**~~ — ✅ resolved in `b511c2b`. `redirect`, `notFound`, `json`, `text`, `html`,
+      `body`, `status`, `header` (`src/runtime/context.ts:400,408,413,418,423,428,436,444`). The intent is
+      right and the messages are excellent, but they are public members marked `@deprecated` that will never be
+      un-deprecated and never removed. **Decide now:** keep them and say in the class doc that they are
+      permanent teaching stubs, or drop them and rely on the type error.
+
+      **Decided: keep, and say so.** The type error is not a substitute — `ctx.redirect('/x')` would become
+          "property does not exist", which says what is wrong and not what to do, and in a JavaScript app nothing
+          at all until `ctx.redirect is not a function` at runtime. The class doc now states that the eight are
+          permanent and that `@deprecated` is there for the strike-through an editor draws with it rather than
+          for its meaning; the API reference says the same, so the tag need not be read as a promise. No
+          behaviour change — the eight were already asserted in the unit suite.
+
+- [x] ~~**5.5 — `PageProps.ctx` is a non-enumerable getter**~~ — ✅ resolved in `d9b6cc9`. So `<Page {...props} />` and any `{...props}`
+      spread silently drop it. Documented at `src/router.ts:67-87` and at `entry.rsc.tsx:184-197`, and
+      unavoidable given the React serialization constraint (an enumerable `ctx` would ship `ctx.hono.env` — every
+      binding and secret — to the browser in dev). But it is the one place the API breaks a JavaScript
+      expectation. Worth a dev-only tripwire, or at minimum a line in the pages docs.
+
+      **Documented, in all three places someone would look** — the `ctx` JSDoc, the page-props docs and the
+          README's limitations — each naming the fix, which is that nested server components call
+          `getRequestContext()` rather than being handed the context. The docs covered the *client* spread
+          already; the case worth writing down is a spread into another **server** component, which fails at
+          nothing and leaves `ctx: undefined` while the type says otherwise.
+
+          **A dev-only tripwire was considered and rejected.** A spread reaches the getter through the same
+          `get` a legitimate `props.ctx` read does, so the only way to tell them apart is to guess from a
+          preceding `ownKeys` — which React's own prop enumeration would trip. Making `ctx` enumerable in dev
+          is the one thing the property exists to prevent.
+
+- [x] ~~**5.6 — `RshonoConfig.trustProxy`'s doc block does not say it is compile-time only.**~~ — ✅ resolved
+      in `b761f22`, with 5.7. `src/runtime/context.ts:114` reads it from the `DefinePlugin` constant, so one
+      artifact cannot be promoted from a direct-exposure staging box to a proxied production one.
+      `README.md` states this plainly; the JSDoc a user actually hovers (`src/config.ts:55-72`) did not — it
+      now carries both that and the `vercel` exception from 5.7.
+
+- [x] ~~**5.7 — The `vercel` target derives the request scheme from `X-Forwarded-Proto` regardless of
+      `trustProxy`.**~~ — ✅ resolved in `b761f22`, folded into 5.6 as suggested. `browserScheme` (`src/deploy/vercel/runtime.ts:18-22`) reads the header and defaults to
+      `https`, and `serveApp` rewrites `incoming.url` with it before Hono sees the request — so `publicUrl(c)`,
+      `ctx.url` and a page's `url` prop reflect it even with `trustProxy: false`. This is **intended and well
+      reasoned** (the doc comment at `:13-16` explains that on this target the header is not client-supplied),
+      and `test/deploy-targets.test.mjs` asserts it. What is missing is that neither the `trustProxy` doc block
+      (`src/config.ts:55-72`) nor the deployment docs mention the exception. Fold into 5.6.
+
+      *Scope note:* the `Host` header is **not** part of this. `@hono/node-server` builds every request URL as
+                      `` `${scheme}://${host}${path}` `` from `incoming.headers.host`, so `Host` is equally load-bearing on the
+                      `node` target and on every Node server ever written. Only the scheme is vercel-specific.
+
+          _Re-checked while fixing:_ the **deployment** docs did already have it ("This needs no `trustProxy`:
+          on this target the header is not client-supplied"). What was missing was the field's own JSDoc, and a
+          precise word in the configuration docs' proxy-header section — which said "leave it off on vercel"
+          without saying that the scheme is honoured regardless. Both now say the exception is the **scheme
+          only**, and the scope note above is stated where a reader will meet it.
+
+- [x] ~~**5.8 — `require('@rshono/core')` fails outright** — verified `ERR_PACKAGE_PATH_NOT_EXPORTED`, since
+      `packages/core/package.json:25-31` declares only `types` and `import` conditions. Correct for an ESM-only
+      framework; worth one documented sentence rather than a discovery.~~ — ✅ resolved in `ecd1731`.
+      Re-verified (`ERR_PACKAGE_PATH_NOT_EXPORTED` against the installed package), then written into the
+      README's limitations and the API reference, each naming the two things that do work: `import`, or
+      `await import()` from CommonJS.
+
+- [x] ~~**5.9 — `ErrorPageInfo.stack` is optional in the type and present only in dev**
+      (`src/runtime/entry.rsc.tsx:503-508`). The `error` page is app-authored, so make the dev-only-ness
+      explicit in the `ErrorPageProps` example.~~ — ✅ resolved in `ecd1731`.
+
+      _Done, and the field's own doc says why it is optional_ — dev-only, not "some errors lack one" — so a
+          page guards on the stack rather than on a mode flag, there being no mode flag to guard on. The example
+          now shows that guard; the routing docs and the API reference say the same. (Both scaffolded and testbed
+          `error` pages already did it correctly; the example was the only place that did not.)
+
+- [x] ~~**5.10 — The prerendered-page `Cache-Control` is hardcoded.**~~ — ✅ resolved in `328e056`.
+      `SSG_CACHE_CONTROL = 'public, max-age=300'` (`src/runtime/entry.rsc.tsx:46`) has no config field and no
+      documented override, and a prerendered site is exactly where a longer `max-age` or a
+      `stale-while-revalidate` belongs. Either expose it or document the supported recipe — and if the recipe
+      is middleware, say explicitly that it has to run **after** `await next()`, since the SSG path passes
+      `cache-control` in the `c.body(...)` header bag (`:446-453`).
+
+      **Decided: document the recipe, keep the constant.** A cache policy is a per-response header and
+          `rshono.config.ts` is compiled into the bundle, so a value that takes a rebuild to change is the wrong
+          shape for one — middleware is the interface the framework already has for response headers. The recipe
+          is now at the constant, in the caching docs and in the static-rendering list, and it says **after
+          `await next()`** as the review asked — verified against Hono directly rather than assumed: a response
+          built with `cache-control` in the `c.body(...)` bag beats a header prepared with `c.header(...)`.
+          (A *dynamic* page is the easier case, since its default is only applied if nothing else set one.)
+
+          Pinned in `prod-config.test.mjs` under a `TESTBED_SSG_CACHE` profile that keeps the `c.header(...)`
+          line which does **not** survive, so the test pins the ordering rather than just the outcome — plus what
+          the edit leaves alone: the `ETag` (revalidation still costs a 304) and the `Vary`.
+
+- [x] ~~**5.11 — `index.ts`'s `@packageDocumentation` omits `publicUrl`.**~~ — ✅ resolved in `2fd1eae`,
+      with the ESM-only note from 5.8 beside it. `src/index.ts:6` describes
+      `@rshono/core/server` as "request context, `redirect`, `notFound`, `onServerError`". `publicUrl` is
+      exported too and is the documented way to give `csrf()` the real origin — the single most important line
+      in the scaffolded `src/server.ts`. (`src/runtime/server.ts`'s own module doc _does_ mention it; the two
+      disagree.)
+
+---
+
+## 6. Test coverage
+
+192 tests over 30 suites. The e2e layers (production, hardened config, per-target, dev, minimal, postcss) plus
+a Playwright suite for the client runtime are genuinely thorough — richer than most frameworks ship. **The gaps
+are concentrated in the unit layer, which imports 12 of the ~49 source modules** (verified from
+`test/unit.test.mjs:11-22`).
+
+_As of `b0039f0`: **281 tests over 42 suites**, the unit layer importing 15 modules, and a coverage floor of
+82 lines / 90 branches / 75 functions over `dist/**` ([6.9](#missing-behavioural-coverage)) so the number
+cannot quietly slide back._
+
+### Tests that are wrong today
+
+- [x] ~~**6.0 — `test/unit.test.mjs:344-351` has one assertion that proves nothing, and a comment that is
+      wrong.**~~ — ✅ resolved in `86f3a0c`, with **one half of the finding withdrawn** — see below. "refuses to escape the ssg directory, decoded form included" runs three paths against a _freshly
+      created empty_ temp dir. `/../` and `/docs/../../etc` are genuinely rejected by the guard; **`/..%2f` is
+      not** — verified directly against `dist/server/prerendered.js`:
+
+      ```
+                      /../             -> null              (rejected by guard)
+                      /..%2f           -> "..%2f/index.html"   ** NOT rejected by guard **
+                      /docs/../../etc  -> null              (rejected by guard)
+                      ```
+
+                      The regex at `src/server/prerendered.ts:43` requires a literal `..` followed by `/` or end-of-string, so
+                      `/..%2f` returns `null` from `readPrerendered` **only because the file is absent**. The comment claims
+                      the encoded form is "decoded *before* the check", which no code in `readPrerendered` does — the actual
+                      decoding happens upstream in Hono's `getPath`.
+                      → **Fix:** assert on `prerenderedRelPath` directly, plant a real file outside the root, and — since the
+                      safety of the encoded case rests entirely on an upstream Hono behaviour — pin that behaviour with a test
+                      of its own. (It *is* safe today; see [Appendix A](#appendix-a--dismissed).)
+
+  **The "proves nothing" half was real and is fixed.** The test now plants the file a traversal is aiming at,
+  one `..` from the root, with a control assertion that the bytes are readable from there — so only the guard
+  can refuse the request. Five attempts including the escaped forms, plus a page of the same name _inside_ the
+  root, so the guard is not simply refusing everything.
+
+  **The `/..%2f` half does not hold against the current tree.** Re-measured: `ssgFilePath('/..%2f')` is
+  `null`, because it decodes **each segment** before checking it — `..%2f` decodes to `../`, which holds a
+  `/` and is not a storable name. `/..%2F` and `/%2e%2e/secret` likewise. The earlier reading was taken
+  against a build from before the per-segment decode ([1.2](#12--blocker-prerendered-pages-whose-params-need-percent-encoding-are-built-and-then-never-served)),
+  and the comment about decoding before the check is accurate — `ssgFilePath` is where it happens.
+
+  **The upstream half was still worth pinning**, and is: the URL parser resolving `%2e%2e` when the `Request`
+  is built, and Hono handing a handler a `decodeURI`'d path. That second test turned up the detail worth
+  having in writing — `decodeURI` leaves reserved escapes alone, so `%2F` reaches the router as an escape
+  rather than a separator, and the framework's own per-segment `decodeURIComponent` is what refuses it as a
+  name. Plus `/..%252f`, pinned as the literal directory name it is so nobody "fixes" it into a traversal.
+
+- [x] ~~**6.0b — `test/prod.test.mjs:141` passes for the wrong reason.**~~ Done with 3.4 in `4f4ae3e`; see 3.4(b) and 3.4(e) for what the replacement can and cannot pin. See
+      [3.4](#34--redirect-raised-after-the-ssr-shell-has-flushed-never-becomes-a-real-3xx), now decided. The
+      replacement needs a `<Suspense>` child that genuinely loses the race, for both `redirect()` and
+      `notFound()`, and must assert the **digest survives the abort** — not merely that a redirect eventually
+      happens. A test that only checks the end state would pass even if the `setImmediate` in 3.4(b) were
+      dropped, which is the exact regression that would break every JavaScript client.
+
+### Missing unit coverage
+
+- [x] ~~**6.1 — `src/runtime/request.ts` has no unit tests at all.** It classifies every request as document /
+      flight / form-action / client-action (`:49-57`), and both the CSRF guard and the `Vary` behaviour hang off
+      that classification. Table-drive `parseRenderRequest` over method × `x-rsc-action` × content-type × `RSC`
+      header, and round-trip `createRscRequest` through it.~~ Done with
+      [2.7](#27--write-down-that-client-initiated-actions-rely-on-the-cors-preflight) in `e3b181c`.
+- [x] ~~**6.2 — `publicUrl` has no unit test.**~~ — ✅ resolved in `1d73740`, every case listed plus a
+      blank first hop, a non-http(s) scheme (compared case-sensitively) and that each call returns a fresh
+      URL. The `trustProxy: true` branch needed a fresh module instance with the `DefinePlugin` global set,
+      since the flag is read once when the module is evaluated. It is reached only through `test/prod-config.test.mjs:122`'s
+      `csrf()` assertions. Cover it directly: `trustProxy` off, `trustProxy` on, a comma-separated forwarded
+      chain (only the first hop is honoured, `src/runtime/context.ts:107-110`), a forwarded host carrying no
+      port (the internal port must be dropped — asserted end-to-end at `test/prod-config.test.mjs:119`, never in
+      isolation), and an unparseable `X-Forwarded-Host`.
+- [x] ~~**6.3 — `src/server/load-config.ts`'s error branches are untested.**~~ — ✅ resolved in `1d73740`:
+      all four branches, plus the `{ts,js,mjs}` scan and its precedence, a relative `--config`, a config that
+      throws being let through as itself, and the `.ts` hint asserted down to the original error surviving as
+      `cause` — with the advice it gives shown to work, from a second directory, because Node's module
+      registry keeps the failed load under its URL. The happy path of `--config` is
+      covered indirectly (`prod-config.test.mjs` builds with `trust-proxy.config.mjs`). Nothing covers: no
+      config file at all (`:30`, returns `{}`), an explicit `--config` pointing at a missing file (`:32`), a
+      config with no default export (`:50`), or the bespoke `.ts`-imports-a-`.js`-specifier hint (`:39-46`).
+- [x] ~~**6.4 — The error-reporting funnel has no unit test.**~~ — ✅ resolved in `1d73740`: the three cases
+      listed, plus the shape a handler is handed, that stderr still gets it, a primitive throw being reported
+      wherever it is caught (nothing can track it), and `waitUntil` on a platform with no execution context
+      — a no-op that swallows a rejection rather than letting a failed report end the process. `reportServerError`'s `alreadyReported`
+      de-duplication (`src/runtime/context.ts:611`), an `onServerError` handler that itself throws (handled at
+      `:616-620` — must be caught, must not fail the request), and re-registration replacing the previous
+      handler (`:598`). `test/prod.test.mjs:385` covers the happy path only.
+- [x] ~~**6.5 — `refusesCrossSiteForm` is tested for three shapes; the ones the §2 items turn on are missing.**~~
+      — ✅ closed: all three were added with 2.3 (`5f296e1`) and 2.4 (`a084b69`); see the note at the end of
+      the item.
+      `test/minimal-app.test.mjs` covers no `Sec-Fetch-Site` + foreign `Origin` (`:73-87`), `cross-site` +
+      mismatched `Origin` (`:95-100`), and `cross-site` + the app's own `Origin` (`:104-109`). **Add:**
+      `same-site` + foreign `Origin` (the subdomain hole,
+      [2.3](#23--the-built-in-csrf-guard-leaves-a-same-site-cross-origin-form-post-to-csrf)), `cross-site` with
+      **no** `Origin` ([2.4](#24--hardening-refusescrosssiteform-allows-sec-fetch-site-cross-site-with-no-origin)),
+      and `Origin: null` (sandboxed iframe or `data:` URL). — ✅ all three added with 2.3 (`5f296e1`) and 2.4
+      (`a084b69`), plus a `same-origin` post whose `Origin` a proxy rewrote.
+- [x] ~~**6.6 — `defineRoutes` has no negative type test.**~~ — ✅ resolved in `18bf56b`:
+      `apps/testbed/types/routes.tsx`, ten `@ts-expect-error` assertions and eleven cases that must still
+      compile — the props mismatch in both overloads, a wrong and an empty `staticPaths` key beside the forms
+      that have to keep working, and the endpoint `method` union. Outside `src/` so nothing bundles it, and
+      inside the testbed's `tsconfig` `include`, so the existing "typecheck against the published types" job
+      runs it with no new CI step. Each directive sits above the whole `defineRoutes(...)` call: inside the
+      array literal it lands a line early and asserts nothing. The `ValidateRoutes` machinery
+      (`src/router.ts:305`) is the most intricate type in the package and its whole job is to _fail_. CI
+      typechecks the testbed, which covers the positive case; nothing asserts that a `PageProps<'/a/:b'>`
+      mismatch is still an error. An `@ts-expect-error` fixture keeps a refactor from silently switching the
+      check off.
+
+### Missing behavioural coverage
+
+- [x] **6.7 — No `HEAD` request anywhere in the suite** — ✅ done with [3.5](#35--a-head-on-a-page-route-renders-the-page-and-throws-the-result-away) in `a9da318`. _(original text below)_ (verified: no `HEAD` in any test source outside built
+      fixtures). Add status, headers, empty body, and that the render is released — see
+      [1.3](#13--blocker-httpmethod-advertises-head-which-can-never-match) and
+      [3.5](#35--a-head-on-a-page-route-renders-the-page-and-throws-the-result-away).
+- [x] ~~**6.8 — No test that two concurrent in-flight requests keep separate `AsyncLocalStorage` contexts.**~~
+      — ✅ resolved in `fe679bd`, at both levels: a `runWithContext` unit test that interleaves four flows
+      (the longest starts first and finishes last) and reads the context on **both sides of an await**, so
+      what is asserted is that the store survives a suspension; and eight concurrent HTTP requests to
+      `/whoami`, which awaits before reading the context and echoes a header and a cookie back, so each
+      response must carry its own values and none of the other seven's. The
+      request context is one of the four boundaries `SECURITY.md` owns; every existing context test is
+      sequential (verified: the only `concurren*` match in the suite is
+      `test/prod-config.test.mjs:14`, a comment about the test runner).
+- [x] ~~**6.9 — No coverage measurement anywhere**~~ — ✅ resolved in `b0039f0`: `test:coverage` is `test`
+      plus Node's own coverage with three thresholds — 82 lines / 90 branches / 75 functions, just under the
+      82.72 / 90.94 / 76.04 measured — and a CI job on Ubuntu runs it. Scoped to `dist/**`, which is the
+      difference between a gate and noise: unscoped, the report fills with the testbed's bundle and the temp
+      directories the e2e suites boot servers from, and the aggregate swings on how many servers a run
+      happened to start. Both directions verified: it passes at those floors and fails when one is raised
+      past what the suite reaches. The number is what the suite reaches **in process**, which is written down
+      beside it so 82% is not read as "18% untested" — the e2e suites run the app in a child process, and
+      `entry.client.tsx` is browser-only. (no `c8` / `nyc` / `--experimental-test-coverage` in
+      `packages/core/package.json:58-59` or `ci.yml`). Wire it with a floor so a new branch cannot land
+      untested; `src/runtime/entry.client.tsx` (471 LOC, browser-only) and the deploy runtimes are the likely
+      blind spots.
+
+### Tests that pin the fixes above
+
+- [x] ~~**6.10** — the [1.2](#12--blocker-prerendered-pages-whose-params-need-percent-encoding-are-built-and-then-never-served)
+      encoded-param SSG round-trip, end to end rather than `interpolatePath` in isolation.~~ — ✅ closed:
+      already covered, in three places. `prod.test.mjs:658` asserts the `café` slug over HTTP in **both**
+      representations, with the `ETag` proving it came off disk, and reads the file at its decoded name;
+      `cloudflare.test.mjs:160` does the same through the asset store; and the unit round trip
+      (`prerenderStaticRoutes` → `readPrerendered`) covers `a b` as well. Ticked rather than added to.
+- [x] ~~**6.11** — the [2.1](#21--the-env-shadow-does-not-cover-processenv-processenv-or-an-aliased-process)
+      env-shadow bypass table, as a loader unit test.~~ — ✅ closed: already there, all six shapes of the
+      table plus `typeof process !== 'undefined'`, beside the `globalThis.process` warning (five spellings),
+      the directive-prologue cases and the fail-the-build-if-the-layer-is-unreadable branch.
+      `env-shadow-loader.cjs` is at 100% line, branch and function coverage.
+- [x] ~~**6.12** — the [3.1](#31--port-binds-a-random-port-instead-of-the-default) `PORT=""` / `PORT=abc` /
+      out-of-range cases for `rshono start`.~~ Done with [3.1](#31--port-binds-a-random-port-instead-of-the-default)
+      in `f71f16a`, plus a `parsePort` table in the unit suite.
+- [x] ~~**6.13** — the [3.2](#32--an-action-request-that-fails-before-its-payload-is-produced-makes-the-browser-throw-a-typeerror)
+      action-then-`onError` payload shape, and a non-flight (413) action response.~~ Done with 3.2 in `ae127b0`:
+      two `prod.test.mjs` cases for the payload shape, one `test/browser` case for the 413 — which only the
+      client runtime can observe, so it does not run under `pnpm test` (see **8.3**).
+- [x] ~~**6.14** — endpoint routes with `method: 'options'`; duplicate route paths; a `routes.ts` that does not
+      use `defineRoutes` — once [1.4](#14--blocker-srcroutests-and-srcserverts-are-cast-not-validated) adds
+      validation, assert the messages.~~ — ✅ resolved in `b0039f0`. The duplicate-path and no-`defineRoutes`
+      messages were already asserted by 1.4's `validateRoutesModule` suite. `method: 'options'` was the gap,
+      and it is the method that matters: no page route will ever answer one, and a cross-origin action needs
+      it answered, since a CORS preflight _is_ an OPTIONS. The testbed now has that endpoint, and the
+      404-not-405 test asserts both halves — the named method reaches the handler, and the same path asked for
+      as a page is still the notFound page.
+- [x] ~~**6.15** — `test:browser` is a separate CI job and not part of `pnpm test`. Fine as a split — worth one
+      line in `CONTRIBUTING.md` so a contributor knows a local `pnpm test` does not cover the client runtime.~~
+      — ✅ resolved in `b0039f0`, in the testing section, naming what only that job can see and when to run it.
+
+---
+
+## 7. Docs and repo hygiene
+
+- [x] ~~**7.1** — `packages/core/README.md:20` — "`react-server-dom-rspack` is still `0.0.x`" contradicts the
+      manifest (`0.1.0`).~~ Resolved with [1.1](#11--blocker-the-published-dependency-versions-have-never-been-tested)
+      in `ee25131`, along with the same claim in the website's `getting-started.md`, the `.d.ts` header and
+      `packages/benchmarks/README.md`; all four now say "pre-1.0" rather than naming a digit.
+- [ ] **7.2** — `packages/core/README.md` "Requirements & limitations" should gain: the `/_static` middleware
+      exception ([2.2](#22--srcserverts-middleware-never-runs-for-_static)), the `HTTPMethod`/`HEAD` note
+      ([1.3](#13--blocker-httpmethod-advertises-head-which-can-never-match)), the prerendered-param encoding
+      constraint ([1.2](#12--blocker-prerendered-pages-whose-params-need-percent-encoding-are-built-and-then-never-served)),
+      the late-control-signal limitation and its app-side fix (3.4(d), **decided**), and the page-route
+      405-vs-404 choice (3.6, **decided**).
+- [ ] **7.3** — Root `tsconfig.json:17` sets `baseUrl`, which `packages/core/README.md:52` tells users
+      TypeScript 7 removed. Harmless (the root builds on TS 6) but it is the repo doing the thing its own docs
+      advise against.
+- [x] ~~**7.4** — `CHANGELOG.md` `[Unreleased]` is empty while `packages/core/package.json` carries an unrecorded
+      dependency bump ([1.1](#11--blocker-the-published-dependency-versions-have-never-been-tested)).~~ Recorded
+      in `ee25131`: `[Unreleased]` now carries the bump, why the pair moves together, and the `check:pins` guard.
+      Anything later items add goes beside it.
+- [ ] **7.5** — Re-read `SECURITY.md` against the code once [2.3](#23--the-built-in-csrf-guard-leaves-a-same-site-cross-origin-form-post-to-csrf)
+      and [2.7](#27--write-down-that-client-initiated-actions-rely-on-the-cors-preflight) are settled. It is a
+      public commitment about what counts as a vulnerability; the wording is defensible today but narrower than
+      it reads.
+- [ ] **7.6** — State the semver story for a pre-1.0 dependency. `README.md` is candid that
+      `rspack.experiments.rsc` is experimental and that `react-server-dom-rspack` is pinned. A `1.0.0` that
+      promises semver on an API built over two pre-1.0 dependencies should say in the README — not only in the
+      changelog — what a breaking upstream change means for the major version.
+
+---
+
+## 8. Release checklist
+
+- [ ] **8.1** — [1.1](#11--blocker-the-published-dependency-versions-have-never-been-tested) resolved and the
+      full suite re-run against the _published_ resolution. **1.1 is resolved** (`ee25131`) and everything that
+      runs without a browser is green against 2.2.1 / 0.1.0 — lint, typecheck, 192/192, testbed, and `scaffold`
+      at 42/42. This stays open on **8.3** alone: `test:browser` has not run against the new pair.
+
+      _Re-run at `e23b5b1`, end of the §4–§6 pass:_ `pnpm check:pins` ✅ (all four pins agree across
+          manifests, overrides, lockfile and `node_modules`), `pnpm lint` ✅, `@rshono/core typecheck` ✅,
+          `@rshono/core test` **281/281** ✅, `testbed typecheck` ✅ (which now runs the negative type tests from
+          [6.6](#missing-unit-coverage)), `@rshono/create typecheck` ✅ and `@rshono/create test` **36/36 + 6
+          skipped** ✅ (the six are the `CREATE_RSHONO_E2E=1` cases). Still open on **8.3** alone.
+
+- [x] ~~**8.2** — `pnpm lint` green.~~ ✅ _Clean at `e23b5b1`, and after every commit of this pass — an
+      earlier review reported two errors; that was stale._
+- [ ] **8.3** — `pnpm --filter @rshono/core test:browser` green on a machine with Chromium. It is the only
+      coverage the client runtime has, it did not run for either review, and
+      [3.4](#34--redirect-raised-after-the-ssr-shell-has-flushed-never-becomes-a-real-3xx)'s recovery path
+      depends on it.
+
+      **Attempted and blocked, not skipped.** Every spec fails at `browserType.launch` with
+          `Received signal 11 SEGV_ACCERR` — Chromium segfaults on launch in this environment (a sandboxed macOS
+          container), before a single page loads. That is environmental and says nothing about the suite: the
+          build step ahead of it succeeds and the failure is identical for all 30 specs. **This is the one item
+          in this document that needs a machine, not a change** — run it on Linux or an unsandboxed macOS
+          checkout. `CONTRIBUTING.md` now says what only this job can see
+          ([6.15](#tests-that-pin-the-fixes-above)), so it is at least hard to forget.
+
+- [x] ~~**8.4** — `pnpm --filter @rshono/core test` green (192+).~~ ✅ **281/281 over 42 suites** at
+      `e23b5b1`, and `test:coverage` green at its floor
+      ([6.9](#missing-behavioural-coverage)): 82.72 lines / 90.94 branches / 76.04 functions over `dist/**`.
+
+      _Windows caveat, found in CI and fixed in `556a580`._ The two `minimal-app` cases that assert a build
+      *fails* with a named validation error were failing on Windows for the wrong reason: the build died first
+      on `Can't resolve '@rshono/core'`. They copy the fixture and borrowed its `node_modules` through a
+      `'junction'` from the OS temp directory — a reparse point to another volume, which the bundler's
+      resolver does not traverse there. `react` and `hono` hid the shape of it, being answered by the
+      *framework's* own tree. The copy now lives one level **inside** the fixture with no `node_modules` of
+      its own, so the resolver walks up and finds the real one: no link, no volume boundary, the same path on
+      every platform. The identical junction in `unit.test.mjs` was never needed and is gone too.
+- [x] ~~**8.5** — CHANGELOG entry under `[Unreleased]` for whatever of the above ships.~~ — ✅ written in
+      `e23b5b1`. `[Unreleased]` carried only the dependency work from 1.1; it now covers the whole pass as
+      **Changed / Added / Fixed / Security**, written for someone upgrading rather than as a commit log, with
+      the two entries that can require a change named up front — the `@rspack/core` /
+      `react-server-dom-rspack` pair, and `HTTPMethod` losing `'head'`.
+- [ ] **8.6** — `SECURITY.md` and `README.md` re-read against the code (7.2, 7.5, 7.6).
+
+      _Partly done, and deliberately not closed._ `README.md` gained what §5 turned up — the non-enumerable
+          `ctx` prop ([5.5](#5-api-surface--the-parts-that-freeze-at-100)) and the ESM-only surface
+          ([5.8](#5-api-surface--the-parts-that-freeze-at-100)) — and the docs gained the `onServerError`,
+          `method`, `staticPaths`, `trustProxy`, `ErrorPageInfo` and prerendered-cache entries. But this item is
+          gated on **7.2, 7.5 and 7.6**, which are §7 and outside this pass: the remaining README additions, the
+          `SECURITY.md` re-read, and the semver story for a pre-1.0 dependency. Leave it open until §7 lands.
+
+---
+
+## Suggested order
+
+1. ~~**[1.1](#11--blocker-the-published-dependency-versions-have-never-been-tested) first.** The dependency drift
+   invalidates every other result in this document, including the 192 passing tests.~~ ✅ **Done** (`ee25131`) —
+   resolved to `@rspack/core` 2.2.1 / `react-server-dom-rspack` 0.1.0, re-verified, and guarded by
+   `pnpm check:pins`. Every measurement below was taken against 2.1.7 / 0.0.3; the suite is green on the new
+   pair, but any _specific_ line number or byte count in this document is worth re-checking as you reach it.
+2. The rest of §1 — [1.2](#12--blocker-prerendered-pages-whose-params-need-percent-encoding-are-built-and-then-never-served)
+   silently disables a headline feature for non-ASCII routes;
+   [1.3](#13--blocker-httpmethod-advertises-head-which-can-never-match) and
+   [1.4](#14--blocker-srcroutests-and-srcserverts-are-cast-not-validated) are type/validation gaps that get
+   harder to close after the freeze.
+3. The two `SECURITY.md`-boundary items in §2: the `process?.env` shadow gap
+   ([2.1](#21--the-env-shadow-does-not-cover-processenv-processenv-or-an-aliased-process)) and the `/_static`
+   middleware gap ([2.2](#22--srcserverts-middleware-never-runs-for-_static)). Then settle the CSRF wording
+   ([2.3](#23--the-built-in-csrf-guard-leaves-a-same-site-cross-origin-form-post-to-csrf)).
+4. §3, starting with [3.1](#31--port-binds-a-random-port-instead-of-the-default) — the only item that
+   misbehaves silently in an otherwise normal deployment — then
+   [3.2](#32--an-action-request-that-fails-before-its-payload-is-produced-makes-the-browser-throw-a-typeerror)
+   and [3.3](#33--a-notfound-or-error-page-that-itself-throws-a-control-signal-produces-a-bodiless-unlogged-500).
+   [3.4](#34--redirect-raised-after-the-ssr-shell-has-flushed-never-becomes-a-real-3xx) and
+   [3.6](#36--any-method-other-than-getpost-on-a-page-route-is-a-404-not-a-405) are **decided** — 3.4 is
+   abort + dev warning + docs, 3.6 is documentation only. Take 3.4(b), the `setImmediate` ordering, with its
+   test rather than after it.
+5. §6 alongside each fix rather than as a batch, plus the coverage gate (6.9) and the concurrency test (6.8).
+6. §5 and §7 last, but **before the tag**: they are the parts that cannot change after 1.0.0 without a major.
+
+---
+
+## Appendix A — dismissed
+
+Findings raised across the two reviews that did **not** survive verification. Recorded so they are not
+re-raised.
+
+- **"Percent-encoded dot segments (`%2e%2e`) can escape the prerender store."** False. Two independent upstream
+  layers strip them before `src/server/prerendered.ts:43` is reached: the URL parser normalises `%2e%2e` as a
+  double-dot segment when the `Request` is constructed (verified:
+  `new URL('/__ssg/docs/%2e%2e/x', base).pathname === '/__ssg/x'`), and Hono's `getPath` then runs `decodeURI`
+  on any path containing `%`. Verified end to end: `GET /docs/%2e%2e` → **404**, never reaching a `/docs/:slug`
+  handler at all. `c.req.path` cannot carry `%2e`.
+  → What _is_ left is a test that passes for the wrong reason and a guard whose correctness depends on an
+  unpinned upstream behaviour — kept as [6.0](#tests-that-are-wrong-today), not as a vulnerability.
+
+- **"A route `path` without a leading `/` silently never matches."** False. Verified: Hono registers `'docs'`
+  and serves `GET /docs` with 200. No fix needed.
+
+- **"`RouterProvider`'s memo never hits."** False. `RouterProvider` is a `'use client'` component whose `href` /
+  `params` props are deserialized from the flight payload, so they are referentially stable across re-renders of
+  the same payload. The `useMemo` at `src/runtime/navigation.tsx:67` busts only when the payload changes or when
+  `router` changes (`pending` toggling) — both times the value genuinely changed. `pageProps` rebuilding
+  `params` per request is irrelevant: that object is serialized, not shared.
+
+- **"Add `Cross-Origin-Opener-Policy` to the baseline header set."** The justification was that an app "cannot
+  retrofit it as easily", which is false — `secureHeaders()` sets COOP in one line, and the framework's stated
+  position is that per-request security is Hono middleware. No defect, no recommendation.
+
+- **"`pnpm lint` fails with 2 errors."** Stale. Verified clean at merge time. (The source review also carried a
+  dangling cross-reference to a section "B" that did not exist in that document.)
+
+- **"The `vercel` target trusts the `Host` header regardless of `trustProxy`."** Corrected rather than dropped.
+  It does — but so does every other target: `@hono/node-server` builds the request URL from `Host` on all of
+  them. Only the `X-Forwarded-Proto` half is vercel-specific, and [5.7](#5-api-surface--the-parts-that-freeze-at-100)
+  says so.
+
+## Appendix B — reconciliation notes
+
+Where the two source reviews disagreed, and how it was settled:
+
+| Disagreement                                                                                                 | Resolution                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lint state (eval 1: 2 errors; eval 2: clean)                                                                 | **Clean.** Verified at merge time. Eval 1's baseline was `554fb76`; its line numbers throughout are stale and have been re-derived against the working tree.                                                                                                                                                                                                  |
+| What triggers the client `TypeError` on an action (eval 1: a render error; eval 2: `loadPage`/`decodeReply`) | **Eval 2.** `renderComponent` returns the stream at `entry.rsc.tsx:256` before the render can throw, so the response is already committed. Merged as [3.2](#32--an-action-request-that-fails-before-its-payload-is-produced-makes-the-browser-throw-a-typeerror), keeping eval 1's separate 413 measurement as shape (a).                                     |
+| `cross-site` with no `Origin` (eval 1: fail-open defect; eval 2: no browser shape reaches it)                | **Eval 2.** Per Fetch, a browser always appends `Origin` to a non-GET/HEAD request. Downgraded to hardening ([2.4](#24--hardening-refusescrosssiteform-allows-sec-fetch-site-cross-site-with-no-origin)); eval 1's substantive `same-site` subdomain point promoted to [2.3](#23--the-built-in-csrf-guard-leaves-a-same-site-cross-origin-form-post-to-csrf). |
+| `HEAD` on a page route (eval 1: "fine, 200 empty body"; eval 2: wasted render, leaked listener)              | **Both true, not contradictory.** Eval 1 measured the status; eval 2 measured the cost. Merged as [3.5](#35--a-head-on-a-page-route-renders-the-page-and-throws-the-result-away).                                                                                                                                                                             |
+| Whether a throwing error page is logged (eval 2: "unlogged")                                                 | **Partly.** The `error`-page path at `:509-513` _is_ guarded and logged; the control-signal re-entry at `:491` is not. Narrowed in [3.3](#33--a-notfound-or-error-page-that-itself-throws-a-control-signal-produces-a-bodiless-unlogged-500).                                                                                                                 |
+| Flight trailer split across batches (eval 1: defect)                                                         | **Downgraded to defence-in-depth** ([4.2](#42--injectflightpayload-has-no-guard-for-a-document-trailer-straddling-two-batches)). The module documents the assumption at `:97-99` and it holds for React today — but this injector exists because a dependency made the same class of assumption and was wrong, so it still warrants a guard.                  |
+
+**Duplicates collapsed:** action-response decoding (eval 1 A2 + eval 2 §3.2) → 3.2 · CSRF guard (C1 + §2.4) →
+2.3 + 2.4 · plain-text 404 cache-control (C3 + §3.5) → 3.8 · 405 vs 404 (E2 + §3.6) → 3.6 · CLI port handling
+(D5 + §3.1) → 3.1 · README `0.0.x` (D8 + §1 + §6.1) → 1.1 + 7.1 · error-funnel tests (F5 + §4.4) → 6.4 ·
+CSRF-shape tests (F3 + §2.4) → 6.5 · browser suite (G2 + §4) → 8.3 + 6.15.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,14 @@ The framework owns four boundaries, and a defect in any of them is a vulnerabili
   not a framework vulnerability. (The one exception the framework does enforce is a form post to a server
   action from another origin — a sibling subdomain included, since `Sec-Fetch-Site: same-site` is what a
   browser labels that — which it refuses whether or not `csrf()` is registered.)
+
+  The _other_ action shape has no such rule and needs none, which is worth writing down because it is
+  load-bearing: a client-initiated action call is selected by the `x-rsc-action` request header, and that is
+  not a CORS-safelisted header. A page on another origin cannot send one without a successful preflight, and
+  the framework answers no preflight, so that shape cannot be forged from a browser at all. An app that adds
+  `cors()` middleware permissive enough to allow `x-rsc-action` from another origin has taken that defence
+  away and is asking for exactly what it asked for; `csrf()` is what should still be standing behind it.
+
 - **Anything reachable only with `trustProxy: true` and no proxy stripping the headers.** That setting is
   documented as "only behind a proxy you control".
 - **Dev-server behaviour.** `rshono dev` binds `127.0.0.1`, serves unminified source and widens `script-src`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,10 @@ The framework owns four boundaries, and a defect in any of them is a vulnerabili
 
 - **The env split.** A `PUBLIC_`-prefixed variable is meant to be the only thing that can reach the browser,
   in the client bundle and in SSR'd output alike. Anything that gets a non-prefixed variable into either is
-  in scope.
+  in scope. The one route the framework cannot cover is a read through the global object —
+  `globalThis.process.env`, `global.process.env` — because the SSR-side shadow replaces the `process`
+  *binding*, which `globalThis.process` goes around. The build warns when a module under `src/` does that;
+  read `process.env` directly and the shadow applies.
 - **Server action dispatch.** Every `'use server'` export is a public HTTP endpoint by design — that is
   documented, and authenticating inside the action is the app's job. What is _not_ by design: running an
   action the request did not name, running one from a cross-site form post, or leaking a thrown action's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,12 +29,12 @@ The framework owns four boundaries, and a defect in any of them is a vulnerabili
   in the client bundle and in SSR'd output alike. Anything that gets a non-prefixed variable into either is
   in scope. The one route the framework cannot cover is a read through the global object —
   `globalThis.process.env`, `global.process.env` — because the SSR-side shadow replaces the `process`
-  *binding*, which `globalThis.process` goes around. The build warns when a module under `src/` does that;
+  _binding_, which `globalThis.process` goes around. The build warns when a module under `src/` does that;
   read `process.env` directly and the shadow applies.
 - **Server action dispatch.** Every `'use server'` export is a public HTTP endpoint by design — that is
   documented, and authenticating inside the action is the app's job. What is _not_ by design: running an
-  action the request did not name, running one from a cross-site form post, or leaking a thrown action's
-  message to the client in production.
+  action the request did not name, running one from a form post made by another origin, or leaking a thrown
+  action's message to the client in production.
 - **The request context.** `getRequestContext()` resolves per request through `AsyncLocalStorage`. Anything
   that makes one request see another's context, cookies or env is in scope.
 - **Prerendered page serving and the response defaults.** Path traversal into the prerender store, a `Vary`
@@ -45,8 +45,9 @@ The framework owns four boundaries, and a defect in any of them is a vulnerabili
 
 - **An app's own middleware, or its absence.** Per-request security is Hono middleware in `src/server.ts` —
   `csrf()`, `bodyLimit()`, `secureHeaders()` — and `create-rshono` scaffolds it. An app that removed it is
-  not a framework vulnerability. (The one exception the framework does enforce is a cross-site form post to a
-  server action, which it refuses whether or not `csrf()` is registered.)
+  not a framework vulnerability. (The one exception the framework does enforce is a form post to a server
+  action from another origin — a sibling subdomain included, since `Sec-Fetch-Site: same-site` is what a
+  browser labels that — which it refuses whether or not `csrf()` is registered.)
 - **Anything reachable only with `trustProxy: true` and no proxy stripping the headers.** That setting is
   documented as "only behind a proxy you control".
 - **Dev-server behaviour.** `rshono dev` binds `127.0.0.1`, serves unminified source and widens `script-src`

--- a/apps/testbed/package.json
+++ b/apps/testbed/package.json
@@ -18,7 +18,7 @@
     "rshono-test-external-client-dep": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^26.2.0",
+    "@types/node": "^26.4.0",
     "@types/react": "^19.2.18",
     "typescript": "^7.0.2"
   }

--- a/apps/testbed/src/components/404.tsx
+++ b/apps/testbed/src/components/404.tsx
@@ -1,7 +1,16 @@
 import type { PageProps } from '@rshono/core';
+import { notFound, redirect } from '@rshono/core/server';
 import { Layout } from './layout';
 
 export default function NotFound({ url }: PageProps) {
+  // A 404 page that fails on demand, which nothing links to: `?boom=notfound` throws the very signal that
+  // brought it here, and `?boom=redirect` sends the visitor somewhere else. The first is the re-entry that
+  // used to escape the framework's error handler as a bodiless, unlogged 500; the second is a real pattern
+  // — "no such profile, go to the list" — that has to keep working from both places a 404 is rendered.
+  const boom = url.searchParams.get('boom');
+  if (boom === 'notfound') notFound();
+  if (boom === 'redirect') redirect('/users');
+
   return (
     <Layout title="404 — rshono">
       <div className="page">

--- a/apps/testbed/src/components/late-signal.tsx
+++ b/apps/testbed/src/components/late-signal.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from 'react';
+import type { PageProps } from '@rshono/core';
+import { notFound, redirect } from '@rshono/core/server';
+import { Layout } from './layout';
+
+/**
+ * A control signal raised from a boundary that resolves well *after* the shell — the case `/suspense-redirect`
+ * deliberately wins the race on.
+ *
+ * There is no 3xx to be had here: the status line and the shell bytes are already on the wire by the time
+ * this runs. What the framework has to do instead is let React write the digest that carries the signal to
+ * the client, and then stop rendering the page nobody will read — which is what {@link SlowSection} is here
+ * to catch it doing.
+ */
+async function LateSection({ signal }: { signal: string | null }) {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  if (signal === 'notfound') notFound();
+  redirect('/login');
+  return null;
+}
+
+/** Still rendering when the late signal arrives, and slow enough that the response cannot have waited for it. */
+async function SlowSection() {
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return <p data-section="slow">the slow section rendered anyway</p>;
+}
+
+export default function LateSignal({ url }: PageProps) {
+  return (
+    <Layout title="Late control signal — rshono">
+      <div className="page">
+        <h1>Late control signal</h1>
+        <Suspense fallback={<p data-section="loading">Loading…</p>}>
+          <LateSection signal={url.searchParams.get('signal')} />
+        </Suspense>
+        <Suspense fallback={<p data-section="slow-loading">Still loading…</p>}>
+          <SlowSection />
+        </Suspense>
+      </div>
+    </Layout>
+  );
+}

--- a/apps/testbed/src/components/unloadable.tsx
+++ b/apps/testbed/src/components/unloadable.tsx
@@ -1,0 +1,10 @@
+// A page module that cannot be evaluated — what a chunk that went missing between deploys looks like from
+// the runtime's side, and the one shape that fails a request *after* a server action has already run.
+//
+// Nothing links here. It exists so the suite can post an action to a page whose render then fails, and check
+// that the action's result still comes back with the `error` page's payload.
+throw new Error('Intentional page-module failure (deploy-drift demo).');
+
+export default function Unloadable() {
+  return null;
+}

--- a/apps/testbed/src/db.ts
+++ b/apps/testbed/src/db.ts
@@ -51,6 +51,19 @@ const docs: Doc[] = [
       { id: 'targets', title: 'Targets' },
     ],
   },
+  {
+    // A slug that has to be percent-encoded to travel in a URL, and so has to survive the round trip from
+    // `staticPaths` to the file on disk to `c.req.path`. Every deploy target is asserted against this one:
+    // when the writer and the reader disagreed about encoding, a page like this was built and never served.
+    slug: 'café',
+    title: 'Café',
+    body: 'A page whose slug is not ASCII, so prerendering it proves the encoding round trip.',
+    sections: [
+      { id: 'encoding', title: 'Encoding' },
+      { id: 'on-disk', title: 'On disk' },
+      { id: 'serving', title: 'Serving' },
+    ],
+  },
 ];
 
 export const fakeDB = {

--- a/apps/testbed/src/leak-helper.ts
+++ b/apps/testbed/src/leak-helper.ts
@@ -1,4 +1,19 @@
+/**
+ * A plain module with no directive of its own, pulled into the browser bundle by the `'use client'`
+ * component that imports it — so it is SSR'd in the layer the env shadow covers.
+ *
+ * Three ways of reaching the same secret, none of them spelled the way the shadow used to be gated on: a
+ * dotted read off the `process` binding. Each one used to render the real value into the HTML stream while
+ * the browser bundle saw the `PUBLIC_`-only view — a leaked secret and a hydration mismatch at once. The
+ * dotted spelling is covered by `counter.tsx` itself; this file deliberately never uses it.
+ *
+ * `typeof`-guarded because this module is in the browser bundle too, where there is no `process` at all and
+ * these spellings compile to a live reference to it.
+ */
 export function readSecretFromHelper() {
-  const { DATABASE_URL } = process.env;
-  return DATABASE_URL ?? process.env.DATABASE_URL ?? '(no secret)';
+  const onServer = typeof process !== 'undefined';
+  const optional = onServer ? process?.env.DATABASE_URL : undefined;
+  const computed = onServer ? process['env'].DATABASE_URL : undefined;
+  const alias = onServer ? process : undefined;
+  return optional ?? computed ?? alias?.env.DATABASE_URL ?? '(no secret)';
 }

--- a/apps/testbed/src/preflight.ts
+++ b/apps/testbed/src/preflight.ts
@@ -1,0 +1,15 @@
+import type { Handler } from 'hono';
+
+/**
+ * A CORS preflight answer — the realistic reason an endpoint route names `method: 'options'`.
+ *
+ * A page route answers `GET`, `POST` and the `HEAD` that rides the `GET`, and nothing else, so an `OPTIONS`
+ * is one of the methods only an endpoint can answer. A client-initiated server action from another origin
+ * needs this one answered before the browser will send the action at all — see SECURITY.md.
+ */
+export const handler: Handler = (c) =>
+  c.body(null, 204, {
+    'access-control-allow-origin': c.req.header('origin') ?? '*',
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'content-type, x-rsc-action, rsc',
+  });

--- a/apps/testbed/src/routes.ts
+++ b/apps/testbed/src/routes.ts
@@ -52,6 +52,11 @@ export const routes = defineRoutes({
       component: () => import('./components/boundary-demo'),
     },
     {
+      // Deliberately broken, and linked from nowhere: its module throws as it evaluates. See the component.
+      path: '/unloadable',
+      component: () => import('./components/unloadable'),
+    },
+    {
       type: 'endpoint',
       path: '/api/quick-health',
       // `'get'` and not `'head'`, which the union no longer offers: Hono dispatches a HEAD as a GET, so

--- a/apps/testbed/src/routes.ts
+++ b/apps/testbed/src/routes.ts
@@ -54,6 +54,9 @@ export const routes = defineRoutes({
     {
       type: 'endpoint',
       path: '/api/quick-health',
+      // `'get'` and not `'head'`, which the union no longer offers: Hono dispatches a HEAD as a GET, so
+      // this one registration answers both — and a HEAD-only route would answer neither.
+      method: 'get',
       server: () => import('./health'),
     },
     {

--- a/apps/testbed/src/routes.ts
+++ b/apps/testbed/src/routes.ts
@@ -52,6 +52,10 @@ export const routes = defineRoutes({
       component: () => import('./components/boundary-demo'),
     },
     {
+      path: '/late-signal',
+      component: () => import('./components/late-signal'),
+    },
+    {
       // Deliberately broken, and linked from nowhere: its module throws as it evaluates. See the component.
       path: '/unloadable',
       component: () => import('./components/unloadable'),

--- a/apps/testbed/src/routes.ts
+++ b/apps/testbed/src/routes.ts
@@ -70,6 +70,14 @@ export const routes = defineRoutes({
     },
     {
       type: 'endpoint',
+      path: '/api/session',
+      // Two methods, one handler. The alternative is `'all'` plus a hand-rolled check, which would also
+      // answer every method nobody asked it to.
+      method: ['get', 'delete'],
+      server: () => import('./session'),
+    },
+    {
+      type: 'endpoint',
       path: '/api/boom',
       server: () => import('./boom'),
     },

--- a/apps/testbed/src/routes.ts
+++ b/apps/testbed/src/routes.ts
@@ -70,6 +70,14 @@ export const routes = defineRoutes({
     },
     {
       type: 'endpoint',
+      path: '/api/preflight',
+      // The one method a page route never answers and a cross-origin action needs answered: a CORS
+      // preflight is an OPTIONS.
+      method: 'options',
+      server: () => import('./preflight'),
+    },
+    {
+      type: 'endpoint',
       path: '/api/session',
       // Two methods, one handler. The alternative is `'all'` plus a hand-rolled check, which would also
       // answer every method nobody asked it to.

--- a/apps/testbed/src/server.ts
+++ b/apps/testbed/src/server.ts
@@ -123,6 +123,24 @@ server.use('*', async (c, next) => {
   c.res.headers.set('X-Response-Time', `${(end - start).toFixed(2)} ms`);
 });
 
+/**
+ * The documented way to change what a prerendered page promises about caching: the framework's
+ * `public, max-age=300` is a per-response header, not a config field, so middleware is the interface.
+ *
+ * **After `await next()`.** The line before it is kept on purpose — it is what a reader tries first, and
+ * prod-config.test.mjs asserts that it does not survive: the SSG path builds its response with
+ * `cache-control` in the bag it hands `c.body(...)`, which replaces a prepared header.
+ *
+ * Env-gated so the rest of the suite still sees the framework's own default; a real app would just set it.
+ */
+if (process.env.TESTBED_SSG_CACHE === '1') {
+  server.use('/docs/*', async (c, next) => {
+    c.header('cache-control', 'public, max-age=1');
+    await next();
+    c.res.headers.set('cache-control', 'public, max-age=86400, stale-while-revalidate=604800');
+  });
+}
+
 /** Reads a value out of a real `node_modules` dependency — see the import at the top of this file. */
 server.get('/api/external-dep', (c) => c.text(EXTERNAL_DEP_MARKER));
 

--- a/apps/testbed/src/server.ts
+++ b/apps/testbed/src/server.ts
@@ -42,9 +42,18 @@ const allowedOrigins = (process.env.TESTBED_ALLOWED_ORIGINS ?? '').split(',').fi
 // Where an error tracker goes. Registered at module load — src/server.ts is imported as the server
 // starts — so every error the framework catches (a thrown action, a failed render, SSR falling
 // over) reaches one place. A real app would call Sentry.captureException here instead of logging.
-onServerError((error, { source, request }) => {
+//
+// `hono` and `waitUntil` are used deliberately rather than for the demonstration. `hono.var` is the only
+// way to reach a request id from here — a `source: 'request'` error is reported from the top-level
+// handler, outside the ambient context `getRequestContext()` needs — and `waitUntil` is what keeps a
+// serverless invocation alive until an asynchronous report has actually been sent.
+onServerError<AppEnv>((error, { source, request, hono, waitUntil }) => {
   const message = error instanceof Error ? error.message : String(error);
-  console.log(`[error-reporter] ${source} ${new URL(request.url).pathname}: ${message}`);
+  waitUntil(
+    Promise.resolve().then(() => {
+      console.log(`[error-reporter] ${source} ${new URL(request.url).pathname} #${hono.var.requestId}: ${message}`);
+    }),
+  );
 });
 
 server.use(trimTrailingSlash({ alwaysRedirect: true }));

--- a/apps/testbed/src/session.ts
+++ b/apps/testbed/src/session.ts
@@ -1,0 +1,9 @@
+import type { Handler } from 'hono';
+
+/**
+ * A two-method endpoint — `method: ['get', 'delete']` in routes.ts.
+ *
+ * One handler for both, which is what a list of methods is for: without it this would have to be
+ * `method: 'all'` plus a hand-rolled method check, and every other method would reach it.
+ */
+export const handler: Handler = (c) => c.json({ method: c.req.method });

--- a/apps/testbed/tsconfig.json
+++ b/apps/testbed/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "types": ["node", "react"]
   },
-  "include": ["src"],
+  "include": ["src", "types"],
   "exclude": ["node_modules"]
 }

--- a/apps/testbed/types/routes.tsx
+++ b/apps/testbed/types/routes.tsx
@@ -1,0 +1,60 @@
+/**
+ * Type-level tests for `defineRoutes`.
+ *
+ * `ValidateRoutes` is the most intricate type in the package and its whole job is to **fail**: a page whose
+ * props do not match its own `path`, a `staticPaths` whose param sets do not fill it. CI typechecks the
+ * testbed against the *published* declarations, which covers the positive case — nothing asserted that the
+ * negative one is still an error, so a refactor could switch the check off in silence.
+ *
+ * Every `@ts-expect-error` below is that assertion: if the check it names stops working, the directive
+ * becomes an unused-directive error and this file fails to compile. Each one sits above the whole
+ * `defineRoutes(...)` call, because that — the argument — is where an overload mismatch is reported.
+ *
+ * Outside `src/`, so nothing bundles it: `tsconfig.json` includes this directory and `rshono build` does
+ * not.
+ */
+import { defineRoutes, type PageProps } from '@rshono/core';
+
+const anyPage = () => Promise.resolve({ default: (_props: PageProps) => null });
+const idPage = () => Promise.resolve({ default: (_props: PageProps<'/u/:id'>) => null });
+const abPage = () => Promise.resolve({ default: (_props: PageProps<'/a/:b'>) => null });
+const endpoint = () => Promise.resolve({ handler: () => new Response('ok') });
+
+// ── The path ↔ props check ─────────────────────────────────────────────────────────────────────────────
+
+export const matchingProps = defineRoutes([{ path: '/u/:id', component: idPage }]);
+export const openProps = defineRoutes([{ path: '/u/:id', component: anyPage }]);
+export const bothForms = defineRoutes({ routes: [{ path: '/u/:id', component: idPage }], notFound: { component: anyPage } });
+
+// @ts-expect-error — props are typed for '/a/:b', the route is '/u/:id'.
+export const mismatchedProps = defineRoutes([{ path: '/u/:id', component: abPage }]);
+// @ts-expect-error — the same mismatch through the config form, which is a separate overload.
+export const mismatchedInConfig = defineRoutes({ routes: [{ path: '/u/:id', component: abPage }] });
+// @ts-expect-error — a params-typed page on a path that has no params at all.
+export const paramsOnAStaticPath = defineRoutes([{ path: '/about', component: idPage }]);
+
+// ── The staticPaths ↔ path check ───────────────────────────────────────────────────────────────────────
+
+export const filledParams = defineRoutes([{ path: '/u/:id', render: 'static', component: idPage, staticPaths: async () => [{ id: '1' }] }]);
+export const extraKeys = defineRoutes([{ path: '/u/:id', render: 'static', component: idPage, staticPaths: async () => [{ id: '1', name: 'a' }] }]);
+// An index signature carries no key to compare, so the type the field itself declares stays accepted and
+// the build reports such a mismatch instead.
+export const openRecord = defineRoutes([
+  { path: '/u/:id', render: 'static', component: idPage, staticPaths: async (): Promise<Array<Record<string, string>>> => [{ id: '1' }] },
+]);
+
+// @ts-expect-error — 'slug' is not a param of '/u/:id'.
+export const wrongKey = defineRoutes([{ path: '/u/:id', render: 'static', component: idPage, staticPaths: async () => [{ slug: 'a' }] }]);
+// @ts-expect-error — a param set that fills nothing.
+export const emptySet = defineRoutes([{ path: '/u/:id', render: 'static', component: idPage, staticPaths: async () => [{}] }]);
+
+// ── Endpoint routes ────────────────────────────────────────────────────────────────────────────────────
+
+export const oneMethod = defineRoutes([{ type: 'endpoint', path: '/api/x', method: 'get', server: endpoint }]);
+export const listedMethods = defineRoutes([{ type: 'endpoint', path: '/api/x', method: ['get', 'delete'], server: endpoint }]);
+export const everyMethod = defineRoutes([{ type: 'endpoint', path: '/api/x', server: endpoint }]);
+
+// @ts-expect-error — there is no 'head': Hono dispatches a HEAD as a GET, so 'get' answers both.
+export const headMethod = defineRoutes([{ type: 'endpoint', path: '/api/x', method: 'head', server: endpoint }]);
+// @ts-expect-error — and not inside a list either.
+export const headInAList = defineRoutes([{ type: 'endpoint', path: '/api/x', method: ['get', 'head'], server: endpoint }]);

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -171,11 +171,16 @@ server.use('/blog/*', async (c, next) => {
 | `EnvVars<E>`         | What `ctx.env` resolves to: `Bindings` merged with `Record<string, string \| undefined>`. |
 | `RedirectStatus`     | `301 \| 302 \| 303 \| 307 \| 308`.                                                        |
 | `ServerErrorHandler` | `(error, context) => void` — what `onServerError` takes.                                  |
-| `ServerErrorContext` | `{ source, request }`, the second argument to that handler.                               |
+| `ServerErrorContext` | `{ source, request, hono, waitUntil }`, the second argument to that handler.               |
 | `ServerErrorSource`  | `'action' \| 'render' \| 'ssr' \| 'request'` — which stage produced the error.            |
 
 An `'action'` error is the one worth wiring up: React sends the client an opaque marker with no message
 in production, so a handler is the only place the real error is visible.
+
+`hono` is the request's Hono context, for `hono.var` and `hono.env` — handed over because
+`getRequestContext()` is not reachable from the handler. `waitUntil` holds a serverless invocation open
+until the report has been sent; see [error reporting](/docs/hono#error-reporting) for what it does per
+target.
 
 ## `@rshono/core/client`
 

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -38,7 +38,7 @@ See [Routing](/docs/routing) and [Configuration](/docs/configuration).
 | `PageComponent<P>`     | A page: a server component returning `ReactNode` or `Promise<ReactNode>`.                                       |
 | `PathParams<P>`        | The `params` record a path pattern implies — `'/users/:id'` → `{ id: string }`. `PageProps` applies it for you. |
 | `PageRoute`            | A path rendered by a server component: `path`, `component`, and optional `render` / `staticPaths`.              |
-| `EndpointRoute`        | A path served by a Hono handler: `type: 'endpoint'`, `path`, `server`, optional `method`.                       |
+| `EndpointRoute`        | A path served by a Hono handler: `type: 'endpoint'`, `path`, `server`, optional `method` (one or a list). |
 | `EndpointServerModule` | What an endpoint's module must export — a single named `handler`.                                               |
 | `Route`                | `PageRoute \| EndpointRoute`.                                                                                   |
 | `RouteConfig<TRoutes>` | The object `defineRoutes` takes: `routes`, plus optional `notFound` and `error`.                                |

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -42,13 +42,13 @@ See [Routing](/docs/routing) and [Configuration](/docs/configuration).
 | `PageComponent<P>`     | A page: a server component returning `ReactNode` or `Promise<ReactNode>`.                                       |
 | `PathParams<P>`        | The `params` record a path pattern implies — `'/users/:id'` → `{ id: string }`. `PageProps` applies it for you. |
 | `PageRoute`            | A path rendered by a server component: `path`, `component`, and optional `render` / `staticPaths`.              |
-| `EndpointRoute`        | A path served by a Hono handler: `type: 'endpoint'`, `path`, `server`, optional `method` (one or a list). |
+| `EndpointRoute`        | A path served by a Hono handler: `type: 'endpoint'`, `path`, `server`, optional `method` (one or a list).       |
 | `EndpointServerModule` | What an endpoint's module must export — a single named `handler`.                                               |
 | `Route`                | `PageRoute \| EndpointRoute`.                                                                                   |
 | `RouteConfig<TRoutes>` | The object `defineRoutes` takes: `routes`, plus optional `notFound` and `error`.                                |
 | `FallbackPage`         | The `notFound` / `error` page shape — a `component` with no path of its own.                                    |
 | `ErrorPageProps<E>`    | `PageProps` plus `error`, for the page declared as `error`.                                                     |
-| `ErrorPageInfo`        | `{ message, stack? }`. Redacted in production: a generic message, and `stack` is `undefined`.                 |
+| `ErrorPageInfo`        | `{ message, stack? }`. Redacted in production: a generic message, and `stack` is `undefined`.                   |
 | `HTTPMethod`           | `'get'` \| `'post'` \| `'put'` \| `'patch'` \| `'delete'` \| `'options'` \| `'all'`. A `HEAD` reaches `'get'`.  |
 | `RshonoConfig`         | Every field of `rshono.config.ts`. All optional.                                                                |
 | `RspackHookContext`    | `{ isServer, isDev }`, handed to the `rspack` config hook.                                                      |
@@ -176,7 +176,7 @@ server.use('/blog/*', async (c, next) => {
 | `EnvVars<E>`         | What `ctx.env` resolves to: `Bindings` merged with `Record<string, string \| undefined>`. |
 | `RedirectStatus`     | `301 \| 302 \| 303 \| 307 \| 308`.                                                        |
 | `ServerErrorHandler` | `(error, context) => void` — what `onServerError` takes.                                  |
-| `ServerErrorContext` | `{ source, request, hono, waitUntil }`, the second argument to that handler.               |
+| `ServerErrorContext` | `{ source, request, hono, waitUntil }`, the second argument to that handler.              |
 | `ServerErrorSource`  | `'action' \| 'render' \| 'ssr' \| 'request'` — which stage produced the error.            |
 
 An `'action'` error is the one worth wiring up: React sends the client an opaque marker with no message

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -45,7 +45,7 @@ See [Routing](/docs/routing) and [Configuration](/docs/configuration).
 | `FallbackPage`         | The `notFound` / `error` page shape — a `component` with no path of its own.                                    |
 | `ErrorPageProps<E>`    | `PageProps` plus `error`, for the page declared as `error`.                                                     |
 | `ErrorPageInfo`        | `{ message, stack? }`. Redacted in production: a generic message, no stack.                                     |
-| `HTTPMethod`           | `'get'` \| `'post'` \| `'put'` \| `'patch'` \| `'delete'` \| `'head'` \| `'options'` \| `'all'`.                |
+| `HTTPMethod`           | `'get'` \| `'post'` \| `'put'` \| `'patch'` \| `'delete'` \| `'options'` \| `'all'`. A `HEAD` reaches `'get'`.  |
 | `RshonoConfig`         | Every field of `rshono.config.ts`. All optional.                                                                |
 | `RspackHookContext`    | `{ isServer, isDev }`, handed to the `rspack` config hook.                                                      |
 | `DeployTarget`         | `'node'` \| `'cloudflare'` \| `'vercel'` \| `'aws-lambda'`.                                                     |

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -117,7 +117,8 @@ work. The long tail — `executionCtx.waitUntil()` and whatever Hono adds next �
 Hono's response builders (`redirect`, `notFound`, `json`, `text`, `html`, `body`, `status`, `header`)
 are present as stubs that throw and name the right API, because a page returns JSX and the framework
 builds the response from it — reaching them through `ctx.hono` bypasses the error without making them
-work.
+work. They are permanent: the strike-through your editor draws over them comes from a `@deprecated` tag
+put there for the strike-through, not because they are going away.
 
 `ctx` cannot be handed to a `'use client'` component — it wraps the live request. Reading it on a
 [`render: 'static'`](/docs/routing#static-rendering) page throws, because there is no request at build

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -72,6 +72,13 @@ In a server component or an action, `getRequestContext().url` is the same value,
 `redirect` and `notFound` never return, so TypeScript narrows away the code after them and you don't
 need to `return` the call. Don't wrap either in a `try/catch` that swallows the signal.
 
+Both have to be reached **before the page shell is sent**. A page streams, so the status line goes out as
+soon as the shell is ready and HTTP has no take-backs after that: called from a `<Suspense>` boundary that
+resolves later, neither can still be a 3xx or a 404. The response is committed as `200 text/html`, a browser
+with JavaScript follows the signal through the payload, and a visitor without it stays on the fallback.
+Decide in middleware or in the page component body, above the boundary — `rshono dev` warns when a signal
+arrives too late.
+
 ```tsx
 import { getRequestContext, redirect } from '@rshono/core/server';
 

--- a/apps/website/content/docs/api.md
+++ b/apps/website/content/docs/api.md
@@ -19,6 +19,10 @@ you need on the server and pass it down as props.
 These three are the whole public surface — the package's `exports` map lists only them, so there is no
 deeper path to import. Everything else is framework plumbing.
 
+All three are **ESM only**: the map declares `import` and `types` conditions and no `require` one, so
+`require('@rshono/core')` is `ERR_PACKAGE_PATH_NOT_EXPORTED`. Use `import`, or `await import()` from
+CommonJS.
+
 ## `@rshono/core`
 
 ### Functions
@@ -44,7 +48,7 @@ See [Routing](/docs/routing) and [Configuration](/docs/configuration).
 | `RouteConfig<TRoutes>` | The object `defineRoutes` takes: `routes`, plus optional `notFound` and `error`.                                |
 | `FallbackPage`         | The `notFound` / `error` page shape — a `component` with no path of its own.                                    |
 | `ErrorPageProps<E>`    | `PageProps` plus `error`, for the page declared as `error`.                                                     |
-| `ErrorPageInfo`        | `{ message, stack? }`. Redacted in production: a generic message, no stack.                                     |
+| `ErrorPageInfo`        | `{ message, stack? }`. Redacted in production: a generic message, and `stack` is `undefined`.                 |
 | `HTTPMethod`           | `'get'` \| `'post'` \| `'put'` \| `'patch'` \| `'delete'` \| `'options'` \| `'all'`. A `HEAD` reaches `'get'`.  |
 | `RshonoConfig`         | Every field of `rshono.config.ts`. All optional.                                                                |
 | `RspackHookContext`    | `{ isServer, isDev }`, handed to the `rspack` config hook.                                                      |

--- a/apps/website/content/docs/configuration.md
+++ b/apps/website/content/docs/configuration.md
@@ -151,7 +151,9 @@ middleware needs the public origin, give it `publicUrl(c)` from `@rshono/core/se
 
 Leave it off on [`vercel`](/docs/deployment#vercels-request-handoff), where the request already arrives with the scheme
 and host the browser used — that platform's edge sets them, and the function cannot be reached around
-it. The setting is for a proxy you put in front yourself, which the framework cannot vouch for.
+it. To be precise about that target: the **scheme** is taken from `X-Forwarded-Proto` whether or not
+`trustProxy` is set, because there it is not client-supplied. The `Host` header is not part of the
+exception. The setting is for a proxy you put in front yourself, which the framework cannot vouch for.
 
 ## Response headers and caching
 

--- a/apps/website/content/docs/configuration.md
+++ b/apps/website/content/docs/configuration.md
@@ -175,6 +175,23 @@ default, and with no directives a shared cache is free to store one user's page 
 next. Set your own value from middleware and it is left alone. **Prerendered pages** keep
 `public, max-age=300` and a weak `ETag`.
 
+Those two values are not config fields: a cache policy is a per-response header, and `rshono.config.ts`
+is compiled into the bundle, so a value you cannot change without a rebuild would be the wrong shape.
+Middleware is the interface — and for a **prerendered** page it has to run **after `await next()`**:
+
+```ts
+// src/server.ts — a documentation site's prerendered tree, cached for a day
+server.use('/docs/*', async (c, next) => {
+  await next();
+  c.res.headers.set('cache-control', 'public, max-age=86400, stale-while-revalidate=604800');
+});
+```
+
+After, because the prerendered response is built with `cache-control` in the header bag, which replaces
+anything `c.header(...)` prepared before the handler ran. A dynamic page is the easier case: its default
+is applied only if nothing else set one, so `c.header(...)` before `await next()` works there. Editing
+`c.res.headers` after works for both, leaves the `ETag` alone, and so keeps revalidation at a 304.
+
 Every page response carries `Vary: RSC`, because one URL answers with either an HTML document or a flight
 payload depending on that request header — the client runtime sends `RSC: 1` to ask for a payload. A header
 of its own rather than `Accept`: a browser's `Accept` string differs by vendor and version, so a CDN keyed on

--- a/apps/website/content/docs/getting-started.md
+++ b/apps/website/content/docs/getting-started.md
@@ -8,7 +8,7 @@ rshono is a web framework built on [Hono](https://hono.dev), [Rspack](https://rs
 (`src/routes.ts`), one optional file (`src/server.ts`), nine exported values.
 
 > **Alpha.** Built on Rspack's experimental RSC support (`rspack.experiments.rsc`) and
-> `react-server-dom-rspack`, which is still `0.0.x`. Both are pinned to exact versions, so a release of
+> `react-server-dom-rspack`, which has not reached 1.0. Both are pinned to exact versions, so a release of
 > rshono is what moves them.
 
 ## Scaffold

--- a/apps/website/content/docs/hono.md
+++ b/apps/website/content/docs/hono.md
@@ -234,10 +234,26 @@ thrown action, a failed render, SSR falling over, anything reaching the top-leve
 ```ts
 import { onServerError } from '@rshono/core/server';
 
-onServerError((error, { source, request }) => {
-  Sentry.captureException(error, { tags: { source }, extra: { url: request.url } });
+onServerError((error, { source, request, hono, waitUntil }) => {
+  waitUntil(
+    Sentry.captureException(error, {
+      tags: { source, requestId: hono.var.requestId },
+      extra: { url: request.url },
+    }),
+  );
 });
 ```
 
 `source` is `'action' | 'render' | 'ssr' | 'request'`. Errors keep going to `stderr` either way, and a
 handler that throws is caught rather than failing the request.
+
+`hono` is the request's Hono context — `hono.var` for what your middleware put there, `hono.env` for
+bindings. It is handed over because `getRequestContext()` is not reachable from this handler: a
+`source: 'request'` error is reported from the top-level handler, outside the ambient context.
+
+`waitUntil` holds the invocation open until the report has been sent. On Cloudflare Workers that is
+`executionCtx.waitUntil`, without which a report started here is cut off the moment the response ends. On
+the `node` and `vercel` targets there is nothing to hold open — the process outlives the response — so it
+is a no-op and the report finishes on its own. On `aws-lambda` it is a no-op as well, because the streaming
+handler exposes no execution context to ask; a slow report there is best-effort, so prefer a tracker that
+batches over one that round-trips per error.

--- a/apps/website/content/docs/pages.md
+++ b/apps/website/content/docs/pages.md
@@ -176,6 +176,10 @@ with whatever arguments it likes. A [CSRF check](/docs/configuration#security-mi
 request came from your own site; it says nothing about _who_ sent it. Authenticate, authorize and validate
 arguments inside the action, exactly as in a route handler.
 
+An action's arguments are decoded from the request body, which means the body is buffered before your code
+sees any of it. Register [`bodyLimit()`](/docs/configuration#security-middleware) so there is a size past
+which that never happens — `rshono build` warns when nothing under `src/` registers one.
+
 ### Errors
 
 Thrown action errors are logged server-side and **redacted in the production payload** — React sends no

--- a/apps/website/content/docs/pages.md
+++ b/apps/website/content/docs/pages.md
@@ -44,6 +44,13 @@ export default function Dashboard({ ctx }: PageProps<'/dashboard', AppEnv>) {
 }
 ```
 
+`ctx` is **non-enumerable**, which is the one place these props break a JavaScript expectation: a
+`<Child {...props} />` spread hands the child `ctx: undefined` — silently, since a spread copies
+enumerables only, and the type still says `ctx` is there. It has to be that way; an enumerable `ctx`
+would put `ctx.hono.env`, every binding and secret, into React's dev-only serialization of a server
+component's props. Don't spread page props: nested server components are meant to ask for the context
+themselves.
+
 Nested server components and `'use server'` actions get no props — they call `getRequestContext()` from
 `@rshono/core/server` for the same object. There, `ctx.params` stands in for the `params` prop and
 `ctx.req` for the parsed request:
@@ -82,7 +89,9 @@ than fixing it.
 - Passing it explicitly (`<Counter ctx={ctx} />`) fails the render with React's _"Only plain objects …
   can be passed to Client Components"_.
 - Spreading page props (`<Counter {...props} />`) drops it silently — a spread copies enumerables only.
-  That spread still fails, on `url`, which is enumerable and just as unserializable.
+  That spread still fails, on `url`, which is enumerable and just as unserializable. Into a **server**
+  child the same spread fails at nothing: `ctx` is simply `undefined` there. Call `getRequestContext()`
+  in the child.
 
 Read what you need on the server and pass plain values down: `url.href`, not `url`.
 

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -91,6 +91,11 @@ An endpoint route is served by a raw Hono handler instead of a component — JSO
 redirects, feeds. `method` defaults to `'all'`. There is no `'head'`: Hono dispatches a `HEAD` as a
 `GET` and strips the body off the response, so `'get'` already answers both.
 
+It is also how you answer a method a page does not. A page route is registered for `GET` and `POST` — plus
+the `HEAD` that rides the `GET` — and anything else is a 404 rather than a 405, deliberately: the `Allow`
+header a 405 owes the client would mean tracking the methods registered per path, for a distinction no client
+here acts on differently.
+
 ```ts
 { type: 'endpoint', path: '/api/health', method: 'get', server: () => import('./health') }
 ```

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -125,7 +125,20 @@ Both are optional, and both are real server components with a page's contract mi
 
 - **`notFound`** — rendered with a 404 for unmatched paths and for `notFound()` calls.
 - **`error`** — rendered with a 500 when a request throws, and given an extra `error` prop: message-only
-  in production, message plus stack in dev.
+  in production, message plus stack in dev. `error.stack` is `undefined` in every build and
+  `error.message` is the generic `'Internal Server Error'`, so render the stack behind a check on the
+  stack itself — there is no mode flag to check:
+
+  ```tsx
+  export default function ServerError({ error }: ErrorPageProps) {
+    return (
+      <Layout>
+        <p>{error.message}</p>
+        {error.stack && <pre>{error.stack}</pre>}
+      </Layout>
+    );
+  }
+  ```
 
 See [Configuration & security](/docs/configuration#no-blank-screens) for what happens when a failure is
 bad enough that the `error` page itself cannot be reached.

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -88,7 +88,8 @@ Rules worth knowing:
 ## Endpoint routes
 
 An endpoint route is served by a raw Hono handler instead of a component — JSON APIs, webhooks,
-redirects, feeds. `method` defaults to `'all'`.
+redirects, feeds. `method` defaults to `'all'`. There is no `'head'`: Hono dispatches a `HEAD` as a
+`GET` and strips the body off the response, so `'get'` already answers both.
 
 ```ts
 { type: 'endpoint', path: '/api/health', method: 'get', server: () => import('./health') }

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -72,6 +72,11 @@ hit a database or the filesystem:
 staticPaths: async () => (await db.docs.all()).map((d) => ({ slug: d.slug })),
 ```
 
+`defineRoutes` checks the param sets against the route's own path, the same way it checks a page's props:
+a set that does not carry every `:param` of the path is a type error where the route is declared, not a
+build-time throw. Keys only — a `staticPaths` typed as returning `Record<string, string>` has none to
+check, so it is accepted and the build reports the mismatch instead.
+
 Rules worth knowing:
 
 - **Reading `ctx` throws.** There is no request at build time. Use `params` and `url`, or make the route

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -89,6 +89,8 @@ Rules worth knowing:
 - **Under a [nonce-based CSP](/docs/configuration#csp)** the document is rendered per request — a
   prerendered file cannot carry a per-request nonce. The flight payload is still served from the
   prerender, and a policy with no nonce in it keeps its prerendered documents too.
+- **`Cache-Control: public, max-age=300`**, with a weak `ETag`. To promise more — a longer `max-age`, a
+  `stale-while-revalidate` — set it from middleware [after `await next()`](/docs/configuration#response-headers-and-caching).
 
 ## Endpoint routes
 

--- a/apps/website/content/docs/routing.md
+++ b/apps/website/content/docs/routing.md
@@ -88,8 +88,9 @@ Rules worth knowing:
 ## Endpoint routes
 
 An endpoint route is served by a raw Hono handler instead of a component — JSON APIs, webhooks,
-redirects, feeds. `method` defaults to `'all'`. There is no `'head'`: Hono dispatches a `HEAD` as a
-`GET` and strips the body off the response, so `'get'` already answers both.
+redirects, feeds. `method` defaults to `'all'`, takes one method or a list of them, and there is no
+`'head'`: Hono dispatches a `HEAD` as a `GET` and strips the body off the response, so `'get'` already
+answers both.
 
 It is also how you answer a method a page does not. A page route is registered for `GET` and `POST` — plus
 the `HEAD` that rides the `GET` — and anything else is a 404 rather than a 405, deliberately: the `Allow`
@@ -98,6 +99,10 @@ here acts on differently.
 
 ```ts
 { type: 'endpoint', path: '/api/health', method: 'get', server: () => import('./health') }
+
+// Two methods, one handler. Without the list this would be `'all'` plus a hand-rolled method check,
+// which also answers every method you did not mean to. `'all'` inside a list is refused.
+{ type: 'endpoint', path: '/api/session', method: ['get', 'delete'], server: () => import('./session') }
 ```
 
 ```ts

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -21,7 +21,7 @@
     "@shikijs/themes": "^4.4.3",
     "gray-matter": "^4.0.3",
     "hono": "^4.13.5",
-    "markdown-it": "^15.0.0",
+    "markdown-it": "^15.0.1",
     "markdown-it-anchor": "^9.2.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",
@@ -29,13 +29,13 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
-    "@types/markdown-it": "^14.1.2",
-    "@types/node": "^26.2.0",
+    "@types/markdown-it": "^14.2.0",
+    "@types/node": "^26.4.0",
     "@types/react": "^19.2.18",
     "postcss": "^8.5.26",
     "postcss-loader": "^8.2.1",
     "tailwindcss": "^4.3.3",
-    "typescript": "~6.0.3",
-    "wrangler": "^4.123.0"
+    "typescript": "^7.0.2",
+    "wrangler": "^4.127.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.8.1",
+    "eslint": "^10.9.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.11.0",
     "prettier": "^3.9.6",
     "prettier-plugin-uncomment": "^1.0.2",
     "typescript": "~6.0.3",
-    "typescript-eslint": "^8.67.0"
+    "typescript-eslint": "^8.68.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "release": "node scripts/release.mjs",
     "release:dry": "node scripts/release.mjs --dry-run",
     "clean": "rm -rf packages/*/dist packages/*/node_modules apps/*/node_modules node_modules",
+    "check:pins": "node scripts/check-pinned-deps.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -109,7 +109,7 @@ These are limitations of the comparison, not of the frameworks. Read them before
 5. **rshono pays a production-install cost the other two don't.** `@rspack/core` sits in
    `@rshono/core`'s `dependencies` rather than `devDependencies` — the bundler is what the CLI it ships
    builds with — so it lands in a production install. `footprint.mjs` measures it.
-6. **rshono is built on experimental `rspack.experiments.rsc` and `react-server-dom-rspack@0.0.x`.**
+6. **rshono is built on experimental `rspack.experiments.rsc` and a pre-1.0 `react-server-dom-rspack`.**
    Those move under it, which is why this is CI infrastructure to re-run per release rather than a
    number to publish once.
 7. **Not measured:** client-side navigation (three different protocols; measuring it badly is worse

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -17,10 +17,11 @@ prerendering, and hard env/secret safety.
 
 > **Release candidate.** The framework itself is covered end to end (see [Testing](#testing)) and its API is
 > settled. What is not settled underneath it: Rspack's RSC support is an experimental API
-> (`rspack.experiments.rsc`) and `react-server-dom-rspack` is still `0.0.x`. Both are pinned to exact
-> versions — in the manifests and in workspace overrides — and a release of rshono is what moves them, so an
-> upstream change reaches you as a tested release rather than as a broken install. That is the whole of the
-> caveat, and it is the reason to read the [changelog](../../CHANGELOG.md) before upgrading.
+> (`rspack.experiments.rsc`) and `react-server-dom-rspack` has not reached 1.0, so its own minor bumps are
+> breaking by convention. Both are pinned to exact versions — in the manifests and in workspace overrides —
+> and a release of rshono is what moves them, so an upstream change reaches you as a tested release rather
+> than as a broken install. That is the whole of the caveat, and it is the reason to read the
+> [changelog](../../CHANGELOG.md) before upgrading.
 
 **Full documentation: [rshono.com/docs](https://www.rshono.com/docs).**
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -313,7 +313,7 @@ Every target streams, which is the bar a new one has to clear.
   `Allow` header a 405 owes the client means tracking the methods registered per path, which is state on a hot
   path for a distinction nothing acts on differently here. An endpoint route is the way to answer a `PUT`,
   `PATCH`, `DELETE` or `OPTIONS`.
-- **A page's `ctx` prop is non-enumerable**, so `<Child {...props} />` hands a *server* child
+- **A page's `ctx` prop is non-enumerable**, so `<Child {...props} />` hands a _server_ child
   `ctx: undefined` — silently, since a spread copies enumerables only, and the type still says it is there.
   It cannot be otherwise: an enumerable `ctx` would put `ctx.hono.env`, every binding and secret, into
   React's dev-only serialization of a server component's props. Nested server components are meant to call

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -310,6 +310,11 @@ Every target streams, which is the bar a new one has to clear.
   `Allow` header a 405 owes the client means tracking the methods registered per path, which is state on a hot
   path for a distinction nothing acts on differently here. An endpoint route is the way to answer a `PUT`,
   `PATCH`, `DELETE` or `OPTIONS`.
+- **A page's `ctx` prop is non-enumerable**, so `<Child {...props} />` hands a *server* child
+  `ctx: undefined` — silently, since a spread copies enumerables only, and the type still says it is there.
+  It cannot be otherwise: an enumerable `ctx` would put `ctx.hono.env`, every binding and secret, into
+  React's dev-only serialization of a server component's props. Nested server components are meant to call
+  `getRequestContext()` rather than be handed the context.
 - The dev proxy doesn't forward WebSocket upgrades to a custom sub-app; production is unaffected.
 - Dev source maps embed the original source of `'use server'` modules (dev binds 127.0.0.1 only, and
   production ships no client source maps).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -287,6 +287,9 @@ Every target streams, which is the bar a new one has to clear.
 - **Node ≥ 22.18** (worker threads, `process.loadEnvFile`, `Promise.withResolvers`, `URL.parse`, and native
   TypeScript stripping, so a `.ts` config needs no loader) and **React ≥ 19.1** (the floor
   `react-server-dom-rspack` requires).
+- **ESM only.** The package declares `import` and `types` conditions and no `require` one, so
+  `require('@rshono/core')` is `ERR_PACKAGE_PATH_NOT_EXPORTED` rather than a working call — deliberately,
+  since the framework's own graph is ESM throughout. Use `import`, or `await import()` from CommonJS.
 - No response compression, no base path (`siteUrl` is a bare origin), and wildcard, optional and regex
   params cannot be prerendered.
 - **No link prefetching**, by choice: a link is one fetch at click time and nothing before it. Speculative

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -306,6 +306,10 @@ Every target streams, which is the bar a new one has to clear.
   payload as a digest, and the client runtime navigates), but a visitor without JavaScript is left on the
   fallback under a 200, and a crawler indexes that 200 as a soft 404. The fix is app-side: decide in Hono
   middleware, or in the page component body above the boundary. `rshono dev` warns when it happens.
+- **A page route answers `GET`, `POST` and `HEAD`.** Every other method is a 404 rather than a 405: the
+  `Allow` header a 405 owes the client means tracking the methods registered per path, which is state on a hot
+  path for a distinction nothing acts on differently here. An endpoint route is the way to answer a `PUT`,
+  `PATCH`, `DELETE` or `OPTIONS`.
 - The dev proxy doesn't forward WebSocket upgrades to a custom sub-app; production is unaffected.
 - Dev source maps embed the original source of `'use server'` modules (dev binds 127.0.0.1 only, and
   production ships no client source maps).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -299,6 +299,13 @@ Every target streams, which is the bar a new one has to clear.
   January 2026. Where it is missing there is no interception at all and every link is a real browser load,
   which a server-rendered app answers correctly; only the soft part is gone. Scroll restoration, the fragment
   jump and the post-navigation focus reset are all the browser's.
+- **`redirect()` and `notFound()` must be reached before the page shell is sent.** A page streams: the status
+  line and the first bytes go out as soon as the shell is ready, and HTTP has no take-backs after that. Called
+  from a `<Suspense>` boundary that resolves later, the signal can no longer be a 3xx or a 404 — the response
+  is already committed as `200 text/html`. A browser with JavaScript still follows it (the signal rides the
+  payload as a digest, and the client runtime navigates), but a visitor without JavaScript is left on the
+  fallback under a 200, and a crawler indexes that 200 as a soft 404. The fix is app-side: decide in Hono
+  middleware, or in the page component body above the boundary. `rshono dev` warns when it happens.
 - The dev proxy doesn't forward WebSocket upgrades to a custom sub-app; production is unaffected.
 - Dev source maps embed the original source of `'use server'` modules (dev binds 127.0.0.1 only, and
   production ships no client source maps).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc --noEmit",
     "test": "npm run build && node --test --test-concurrency=1 \"test/*.test.mjs\"",
+    "test:coverage": "npm run build && node --experimental-test-coverage --test-coverage-include=\"dist/**\" --test-coverage-lines=82 --test-coverage-branches=90 --test-coverage-functions=75 --test --test-concurrency=1 \"test/*.test.mjs\"",
     "test:browser": "npm run build && playwright test",
     "prepack": "npm run build"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,16 +61,16 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.1.1",
-    "@rspack/core": "2.2.0",
+    "@rspack/core": "2.2.1",
     "@rspack/plugin-react-refresh": "2.0.2",
     "react-refresh": "0.18.0",
     "react-server-dom-rspack": "0.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",
-    "@types/node": "^26.2.0",
+    "@types/node": "^26.4.0",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.4",
+    "@types/react-dom": "^19.2.5",
     "hono": "^4.13.5",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/packages/core/src/builder/env-shadow-loader.cjs
+++ b/packages/core/src/builder/env-shadow-loader.cjs
@@ -59,7 +59,7 @@ const MENTIONS_PROCESS = /\bprocess\b/;
  * for the app's own source, since a library feature-detecting `globalThis.process?.env?.NODE_ENV` is doing
  * nothing wrong and has no app secret to read.
  */
-const GLOBAL_PROCESS = /\b(?:globalThis|global|self)\s*\??\s*(?:\.\s*process\b|\[\s*(['"`])process\1\s*\])/;
+const GLOBAL_PROCESS = /\b(?:globalThis|global|self)\s*(?:\?\.|\.)?\s*(?:process\b|\[\s*(['"`])process\1\s*\])/;
 
 /**
  * Shadows `process.env` with the PUBLIC_-only view inside SSR-layer modules, so a secret read from a

--- a/packages/core/src/builder/env-shadow-loader.cjs
+++ b/packages/core/src/builder/env-shadow-loader.cjs
@@ -21,6 +21,47 @@ const DIRECTIVE = '([\'"])use [a-z -]+\\1\\s*;?';
 const DIRECTIVE_PROLOGUE = new RegExp(`^${TRIVIA}(?:${DIRECTIVE}${TRIVIA})*`);
 
 /**
+ * The gate: a standalone `process` identifier anywhere in the module, not the literal text `process.env`.
+ *
+ * The prelude replaces the whole `process` *binding*, so every way of reaching the env through that binding is
+ * covered once it is emitted — but a gate on `process.env` only ever saw one of them:
+ *
+ * | source shape                            | `process.env` | this |
+ * | --------------------------------------- | ------------- | ---- |
+ * | `process.env.DATABASE_URL`              | yes           | yes  |
+ * | `const { DATABASE_URL } = process.env`  | yes           | yes  |
+ * | `process?.env.DATABASE_URL`             | **no**        | yes  |
+ * | `process['env'].DATABASE_URL`           | **no**        | yes  |
+ * | `const { env } = process`               | **no**        | yes  |
+ * | `const p = process; p.env.DATABASE_URL` | **no**        | yes  |
+ *
+ * `process?.env` is not a contrived shape — it is how env access is written in code meant to run in a browser
+ * and on a server, which is exactly what a `'use client'` component is. Every "no" above rendered a secret into
+ * the SSR'd HTML while the browser bundle saw the `PUBLIC_`-only view.
+ *
+ * `\b` on both sides, so `preprocess`, `processEnv` and `child_process` do not drag the prelude in. The cost of
+ * being wrong either way is only bytes: a module that mentions `process` in a comment gets a prelude it does
+ * not need.
+ *
+ * The one shape this cannot cover is a module that declares its own module-scope `process` binding — the
+ * prelude would be a redeclaration, and the build fails on it rather than shipping. Naming a module-scope
+ * binding after a well-known global is what has to give.
+ */
+const MENTIONS_PROCESS = /\bprocess\b/;
+
+/**
+ * A read of `process` through the global object rather than through the binding — `globalThis.process.env`,
+ * `globalThis?.process`, `global['process']`, and the `self` spelling Workers use.
+ *
+ * A prelude declares a module-scoped binding, so it cannot reach any of these: `globalThis.process` is the real
+ * `process` however the module names it. `typeof globalThis.process !== 'undefined' && …` is a real isomorphic
+ * idiom, so this is worth saying out loud rather than leaving to be discovered in a rendered page — but only
+ * for the app's own source, since a library feature-detecting `globalThis.process?.env?.NODE_ENV` is doing
+ * nothing wrong and has no app secret to read.
+ */
+const GLOBAL_PROCESS = /\b(?:globalThis|global|self)\s*\??\s*(?:\.\s*process\b|\[\s*(['"`])process\1\s*\])/;
+
+/**
  * Shadows `process.env` with the PUBLIC_-only view inside SSR-layer modules, so a secret read from a
  * `'use client'` component renders empty on the server rather than leaking into the HTML stream — and SSR
  * keeps agreeing with hydration, which sees the same view via DefinePlugin.
@@ -30,8 +71,10 @@ const DIRECTIVE_PROLOGUE = new RegExp(`^${TRIVIA}(?:${DIRECTIVE}${TRIVIA})*`);
  * guarantee with nothing to notice.
  */
 module.exports = function envShadowLoader(source) {
-  if (!source.includes('process.env')) return source;
-  const { prelude, layer } = this.getOptions();
+  // Two steps rather than the regex alone: this loader sees every module in the bundle, and most of them do
+  // not contain the substring at all, which `includes` settles far more cheaply than a scan for word breaks.
+  if (!source.includes('process') || !MENTIONS_PROCESS.test(source)) return source;
+  const { prelude, layer, appSrcPrefix } = this.getOptions();
   if (!this._module) {
     throw new Error(
       "[rshono] env-shadow-loader could not read the module's layer (Rspack's `this._module` is unavailable). " +
@@ -40,6 +83,19 @@ module.exports = function envShadowLoader(source) {
     );
   }
   if (this._module.layer !== layer) return source;
+
+  if (appSrcPrefix && this.resourcePath?.startsWith(appSrcPrefix) && GLOBAL_PROCESS.test(source)) {
+    // Rspack prints the module path ahead of this, so the message is only the part it does not know.
+    this.emitWarning(
+      new Error(
+        '[rshono] This module reads `process` through the global object. It is rendered on the server as part ' +
+          'of a client component, where `process.env` is shadowed with the `PUBLIC_`-only view — and that ' +
+          'shadow is a binding, so it cannot cover `globalThis.process`. A variable read that way is the real ' +
+          'one, and it ends up in the HTML. Read `process.env` directly instead.',
+      ),
+    );
+  }
+
   const prologue = source.match(DIRECTIVE_PROLOGUE)[0];
   return prologue + prelude + source.slice(prologue.length);
 };

--- a/packages/core/src/builder/rspack-config.ts
+++ b/packages/core/src/builder/rspack-config.ts
@@ -2,7 +2,7 @@ import { rspack, type Compiler, type RspackOptions, type RuleSetRule } from '@rs
 import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { basename, dirname, join, win32 } from 'node:path';
+import { basename, dirname, join, sep, win32 } from 'node:path';
 import type { RshonoConfig } from '../config.js';
 import type { DeployPreset } from '../deploy/presets.js';
 import { resolveServerConfig } from '../server/server-config.js';
@@ -293,7 +293,7 @@ export function createConfigs(options: RspackConfigOptions): [RspackOptions, Rsp
           // the same layer, and scoping this to the app's own source left those rendering against the real
           // `process.env` while the browser bundle saw the `PUBLIC_`-only view — a hydration mismatch on
           // anything the host sets, and a leak for anything secret. The loader's own layer check is what
-          // decides; every other module gets one `includes('process.env')` scan.
+          // decides; every other module gets one `includes('process')` scan.
           test: /\.[cm]?[tj]sx?$/,
           enforce: 'pre',
           use: [
@@ -306,6 +306,11 @@ export function createConfigs(options: RspackConfigOptions): [RspackOptions, Rsp
               options: {
                 prelude: `const process = Object.assign(Object.create(globalThis.process ?? Object.prototype), { env: ${JSON.stringify(publicEnv(isDev))} }); `,
                 layer: Layers.ssr,
+                // Only the app's own source is warned about when it reaches `process` through the global
+                // object, which no prelude can shadow — a library feature-detecting `globalThis.process` is
+                // doing nothing wrong and has no app secret to read. The separator is part of the prefix so
+                // a sibling directory named `src-old` is not mistaken for it.
+                appSrcPrefix: srcDir + sep,
               },
             },
           ],

--- a/packages/core/src/builder/rspack-config.ts
+++ b/packages/core/src/builder/rspack-config.ts
@@ -1,6 +1,6 @@
 import { rspack, type Compiler, type RspackOptions, type RuleSetRule } from '@rspack/core';
 import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { basename, dirname, join, sep, win32 } from 'node:path';
 import type { RshonoConfig } from '../config.js';
@@ -104,6 +104,30 @@ export interface RspackConfigOptions {
   onServerComponentChanges?: () => void;
 }
 
+/** Source files worth reading for {@link mentions} — the app's own code, whatever dialect it is written in. */
+const SOURCE_FILE = /\.[cm]?[jt]sx?$/;
+
+/**
+ * Whether `identifier` appears anywhere in the app's own source. The whole tree rather than `src/server.ts`
+ * alone, so middleware registered from a helper module counts.
+ *
+ * A textual scan on purpose. What is being answered is "did the author think about this at all", which is a
+ * question a build warning is allowed to get wrong: the failure mode is a warning that is unwarranted, never a
+ * build that fails or a behaviour that changes. Resolving it properly would mean reading the module graph, and
+ * a middleware registered from a package outside `src/` would still slip past.
+ */
+function mentions(srcDir: string, identifier: string): boolean {
+  try {
+    for (const entry of readdirSync(srcDir, { recursive: true, withFileTypes: true })) {
+      if (!entry.isFile() || !SOURCE_FILE.test(entry.name)) continue;
+      if (readFileSync(join(entry.parentPath, entry.name), 'utf8').includes(identifier)) return true;
+    }
+  } catch {
+    // An unreadable `src/` is not this function's to report: the build is about to fail on `routes.ts`.
+  }
+  return false;
+}
+
 export function createConfigs(options: RspackConfigOptions): [RspackOptions, RspackOptions] {
   const { rootDir, isDev, config, preset, onServerComponentChanges } = options;
   const srcDir = join(rootDir, 'src');
@@ -123,11 +147,22 @@ export function createConfigs(options: RspackConfigOptions): [RspackOptions, Rsp
   // Optional, and staying optional — but per-request security is Hono middleware registered there, so an app
   // without one has opted out of all of it, which is worth hearing once rather than discovering. Builds only:
   // `dev` would print it on every rebuild, and it is not news on a developer's machine.
-  if (!serverAppFile && !isDev) {
-    console.warn(
-      '  ⚠ No src/server.ts — this build has no CSRF check and no request body cap. Both are Hono middleware\n' +
-        '    (`csrf()`, `bodyLimit()`); `npx @rshono/create` scaffolds a src/server.ts with them registered.',
-    );
+  if (!isDev) {
+    if (!serverAppFile) {
+      console.warn(
+        '  ⚠ No src/server.ts — this build has no CSRF check and no request body cap. Both are Hono middleware\n' +
+          '    (`csrf()`, `bodyLimit()`); `npx @rshono/create` scaffolds a src/server.ts with them registered.',
+      );
+    } else if (!mentions(srcDir, 'bodyLimit')) {
+      // Having a src/server.ts is not the same as having the cap in it, and this half used to be warned about
+      // nowhere: every `'use server'` export is a public POST endpoint by design, and the action path buffers
+      // the whole body before it can decide anything about it.
+      console.warn(
+        "  ⚠ No bodyLimit() anywhere in src/ — this build has no request body cap. Every 'use server' export is\n" +
+          '    a public POST endpoint, and the action path buffers whatever arrives before it can reject it.\n' +
+          '    Add `server.use(bodyLimit({ maxSize: 1024 * 1024 }))` to src/server.ts (from `hono/body-limit`).',
+      );
+    }
   }
 
   const rscEntry = join(FRAMEWORK_DIST, 'runtime', 'entry.rsc.js');

--- a/packages/core/src/cli/build.ts
+++ b/packages/core/src/cli/build.ts
@@ -18,6 +18,27 @@ interface BuildOptions {
   preset: DeployPreset;
 }
 
+/**
+ * Loads the built server bundle, which the prerender pass renders through.
+ *
+ * Its module scope is where `src/routes.ts` and `src/server.ts` are validated, so a throw from here is
+ * usually a message written for whoever is running the build — printed as one, rather than as a stack
+ * through the minified frames of a bundle they did not write.
+ */
+async function importServerBundle(distDir: string): Promise<{ app: Hono; routes: readonly Route[] }> {
+  try {
+    return (await import(pathToFileURL(join(distDir, 'server', 'main.mjs')).href)) as {
+      app: Hono;
+      routes: readonly Route[];
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith('[rshono]')) throw error;
+    console.error(`\n  ✗ ${message}\n`);
+    process.exit(1);
+  }
+}
+
 export async function buildCommand(options: BuildOptions): Promise<void> {
   const { rootDir, config, preset } = options;
   const distDir = join(rootDir, BUILD_OUT_DIR);
@@ -52,10 +73,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
   const ssgDir = join(distDir, 'ssg');
   await rm(ssgDir, { recursive: true, force: true });
   process.env.RSHONO_PRERENDER = '1';
-  const bundle = (await import(pathToFileURL(join(distDir, 'server', 'main.mjs')).href)) as {
-    app: Hono;
-    routes: readonly Route[];
-  };
+  const bundle = await importServerBundle(distDir);
   const { written, skipped } = await prerenderStaticRoutes({
     routes: bundle.routes,
     fetch: (request) => bundle.app.fetch(request),

--- a/packages/core/src/cli/build.ts
+++ b/packages/core/src/cli/build.ts
@@ -60,6 +60,9 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
     console.error(stats.toString({ preset: 'errors-warnings', colors: true }));
     process.exit(1);
   }
+  // Printed rather than left to the summary below, which counts warnings without saying what they are —
+  // and one of them is the env shadow reporting a read it cannot cover. See `env-shadow-loader.cjs`.
+  if (stats.hasWarnings()) console.warn(stats.toString({ preset: 'errors-warnings', colors: true }));
   console.log(stats.toString({ preset: 'summary', colors: true }));
 
   const publicDir = join(rootDir, 'public');

--- a/packages/core/src/cli/dev.ts
+++ b/packages/core/src/cli/dev.ts
@@ -205,6 +205,9 @@ export async function devCommand(options: DevOptions): Promise<void> {
       return;
     }
     if (multiStats && !multiStats.hasErrors()) {
+      // Errors print themselves through the per-compiler `done` hooks; a warning has nowhere else to go, and
+      // the env shadow reports what it cannot cover that way. See `env-shadow-loader.cjs`.
+      if (multiStats.hasWarnings()) console.warn(multiStats.toString({ preset: 'errors-warnings', colors: true }));
       const seconds = Math.max(...multiStats.stats.map((s) => (s.endTime ?? 0) - (s.startTime ?? 0))) / 1000;
       console.log(`  ${firstBuild ? '✓ built' : '✓ rebuilt'} in ${seconds.toFixed(1)}s`);
       firstBuild = false;

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -3,6 +3,7 @@ import { parseArgs } from 'node:util';
 import { DEPLOY_TARGETS, resolveDeployPreset } from '../deploy/presets.js';
 import { loadConfig } from '../server/load-config.js';
 import { loadEnvFiles } from '../server/load-env.js';
+import { parsePort } from '../server/server-config.js';
 
 // The commands are imported where they are dispatched: `build` and `dev` pull in Rspack, and a static import
 // would load it for `start` too — ~30 MB of RSS and ~70ms of startup that would then sit in the server's own
@@ -22,6 +23,16 @@ Options:
   -h, --help          show this help
   -v, --version       print the version
 `;
+
+/** {@link parsePort}, reported the way the CLI reports every other bad input: one line, no stack. */
+function readPort(value: string | undefined, source: string): number | undefined {
+  try {
+    return parsePort(value, source);
+  } catch (error) {
+    console.error(`rshono: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
 
 async function main(): Promise<void> {
   const { values, positionals } = parseArgs({
@@ -52,14 +63,9 @@ async function main(): Promise<void> {
   loadEnvFiles(rootDir);
   const config = await loadConfig(rootDir, values.config);
 
-  const flagPort = values.port ? Number(values.port) : undefined;
-  if (values.port && Number.isNaN(flagPort)) {
-    console.error(`rshono: invalid --port "${values.port}"`);
-    process.exit(1);
-  }
-  // Precedence: --port flag > PORT env > the command's built-in default.
-  const envPort = process.env.PORT ? Number(process.env.PORT) : undefined;
-  const port = flagPort ?? envPort;
+  // Precedence: --port flag > PORT env > the command's built-in default. Both sources go through the same
+  // parse as the bundle's own, so `PORT=""` means "unset" in the CLI and in the server it starts alike.
+  const port = readPort(values.port, '--port') ?? readPort(process.env.PORT, 'PORT');
   const host = process.env.HOST;
 
   switch (command) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -62,6 +62,16 @@ export interface RshonoConfig {
    * Middleware in `src/server.ts` reads Hono's `c.req.url` — the *internal* address — whatever this
    * says, so give `csrf()` the public origin explicitly.
    *
+   * **Compiled into the server bundle**, not read at runtime, so it takes a rebuild to change and there is
+   * no environment variable for it: one artifact cannot be promoted from a direct-exposure staging box to a
+   * proxied production one.
+   *
+   * **The `vercel` target is the exception, for the scheme only.** TLS terminates at that platform's edge
+   * and the function is reached over plain HTTP, so the request is rebuilt from `X-Forwarded-Proto`
+   * whatever this says — the function is reachable only through the edge, which sets the header on every
+   * request, so it is not client-supplied there. The `Host` header is not part of the exception, and is no
+   * more trusted on that target than on any other.
+   *
    * @example
    * ```ts
    * export default defineConfig({ trustProxy: true });

--- a/packages/core/src/deploy/cloudflare/runtime.ts
+++ b/packages/core/src/deploy/cloudflare/runtime.ts
@@ -1,5 +1,5 @@
 import type { Context, Hono } from 'hono';
-import { createPageCache, ssgAssetPath, ssgFilePath, toPrerenderedPage, type PrerenderedPage } from '../../server/prerendered.js';
+import { createPageCache, ssgAssetPath, ssgFilePath, SSG_MANIFEST_FILE, toPrerenderedPage, type PrerenderedPage } from '../../server/prerendered.js';
 import type { DeployRuntime } from '../contract.js';
 
 /**
@@ -48,6 +48,27 @@ function serveAsset(asset: Response): Response {
 /** Prerendered pages, keyed by the path that produced them. Per isolate rather than per process. */
 const pageCache = createPageCache();
 
+/** The store's own index of itself, fetched once per isolate — see {@link SSG_MANIFEST_FILE}. */
+let storeIndex: Promise<ReadonlySet<string> | null> | undefined;
+
+/**
+ * What the store holds, or `null` where there is no manifest to read — an older build, or a deployment with
+ * no assets binding at all. `null` gates nothing, which is how it behaved before there was an index.
+ *
+ * Worth one fetch per isolate: without it every request for a path the build did not prerender spends a
+ * subrequest asking the binding for a file that is not there, and misses are deliberately not cached.
+ */
+function knownFiles(c: Context): Promise<ReadonlySet<string> | null> {
+  storeIndex ??= assetResponse(c, `${SSG_PREFIX}/${SSG_MANIFEST_FILE}`)
+    .then(async (asset) => {
+      if (!asset || asset.status !== 200) return null;
+      const manifest = (await asset.json()) as { files?: string[] };
+      return new Set(manifest.files ?? []);
+    })
+    .catch(() => null);
+  return storeIndex;
+}
+
 /**
  * Cloudflare Workers: the host owns the process, so there is nothing to listen on, and there is no filesystem,
  * so `.env` files are out. What is left is the assets binding, which every read here goes through.
@@ -84,6 +105,9 @@ export const runtime: DeployRuntime = {
     const key = `${variant}\0${relPath}`;
     const cached = pageCache.get(key);
     if (cached) return cached;
+
+    const index = await knownFiles(c);
+    if (index && !index.has(relPath)) return null;
 
     // Escaped on the way into the URL and decoded again by the store, so this lands on the file the build
     // wrote under exactly `relPath` — a page whose slug holds a `#` or a `?` included.

--- a/packages/core/src/deploy/cloudflare/runtime.ts
+++ b/packages/core/src/deploy/cloudflare/runtime.ts
@@ -1,5 +1,5 @@
 import type { Context, Hono } from 'hono';
-import { createPageCache, prerenderedRelPath, toPrerenderedPage, type PrerenderedPage } from '../../server/prerendered.js';
+import { createPageCache, ssgAssetPath, ssgFilePath, toPrerenderedPage, type PrerenderedPage } from '../../server/prerendered.js';
 import type { DeployRuntime } from '../contract.js';
 
 /**
@@ -77,14 +77,16 @@ export const runtime: DeployRuntime = {
   },
 
   async readPrerendered(c: Context, variant): Promise<PrerenderedPage | null> {
-    const relPath = prerenderedRelPath(c.req.path, variant);
+    const relPath = ssgFilePath(c.req.path, variant);
     if (relPath === null) return null;
 
     const key = `${variant}\0${relPath}`;
     const cached = pageCache.get(key);
     if (cached) return cached;
 
-    const asset = await assetResponse(c, `${SSG_PREFIX}/${relPath}`);
+    // Escaped on the way into the URL and decoded again by the store, so this lands on the file the build
+    // wrote under exactly `relPath` — a page whose slug holds a `#` or a `?` included.
+    const asset = await assetResponse(c, `${SSG_PREFIX}/${ssgAssetPath(relPath)}`);
     if (!asset || asset.status !== 200) return null;
 
     // The store's own validator where it has one — it already describes these exact bytes.

--- a/packages/core/src/deploy/cloudflare/runtime.ts
+++ b/packages/core/src/deploy/cloudflare/runtime.ts
@@ -61,14 +61,15 @@ export const runtime: DeployRuntime = {
   mountStaticAssets(app: Hono): void {
     // Normally dead — the CDN answers `/_static/*` before the worker is invoked — but keeps the deployment
     // correct, if slower, under an assets configuration that routes everything to the worker first.
-    app.on(['GET', 'HEAD'], '/_static/*', async (c, next) => {
+    // `GET` covers `HEAD` — Hono dispatches one as the other. See `HTTPMethod`.
+    app.get('/_static/*', async (c, next) => {
       const asset = await assetResponse(c, c.req.path, c.req.raw.headers);
       return asset && asset.status !== 404 ? serveAsset(asset) : next();
     });
   },
 
   mountPublicFallback(app: Hono): void {
-    app.on(['GET', 'HEAD'], '/*', async (c, next) => {
+    app.get('/*', async (c, next) => {
       // The prerender tree lives in the same store, but the app only serves it through `readPrerendered`.
       if (c.req.path.startsWith(`${SSG_PREFIX}/`)) return next();
       const asset = await assetResponse(c, c.req.path, c.req.raw.headers);

--- a/packages/core/src/deploy/contract.ts
+++ b/packages/core/src/deploy/contract.ts
@@ -42,7 +42,11 @@ export interface DeployRuntime {
    * request-handling code below can assume has already happened.
    */
   serveApp(app: Hono): unknown;
-  /** Mounts the hashed client bundle at `/_static`, ahead of the app's routes. A no-op where a CDN serves it. */
+  /**
+   * Mounts the hashed client bundle at `/_static` — after src/server.ts, so the app's own middleware covers an
+   * asset response too, and ahead of the page routes, which cannot claim that prefix. A no-op where a CDN
+   * serves it.
+   */
   mountStaticAssets(app: Hono): void;
   /** Mounts `public/` at the web root, after every route, so it only answers paths no route claimed. */
   mountPublicFallback(app: Hono): void;

--- a/packages/core/src/deploy/contract.ts
+++ b/packages/core/src/deploy/contract.ts
@@ -52,7 +52,7 @@ export interface DeployRuntime {
    *
    * Takes the whole {@link Context} because without a filesystem the store *is* a request-scoped
    * binding (`c.env.ASSETS` on Workers). The path is untrusted either way, so an implementation treats
-   * traversal as a miss — see `prerenderedRelPath`.
+   * traversal as a miss — see `ssgFilePath`, the one mapping from a path to the file that holds its page.
    */
   readPrerendered(c: Context, variant: PrerenderVariant): Promise<PrerenderedPage | null>;
   /** Loads `.env` files where the platform has a filesystem. Env is bindings elsewhere. */

--- a/packages/core/src/deploy/filesystem.ts
+++ b/packages/core/src/deploy/filesystem.ts
@@ -44,7 +44,8 @@ export const fileSystemRuntime: Omit<DeployRuntime, 'serveApp'> = {
 
   mountPublicFallback(app: Hono): void {
     if (!existsSync(publicDir)) return;
-    app.on(['GET', 'HEAD'], '/*', createPublicFallback({ root: publicDir, isDev }));
+    // `GET` covers `HEAD` — Hono dispatches one as the other. See `HTTPMethod`.
+    app.get('/*', createPublicFallback({ root: publicDir, isDev }));
   },
 
   readPrerendered(c, variant) {

--- a/packages/core/src/deploy/node/runtime.ts
+++ b/packages/core/src/deploy/node/runtime.ts
@@ -1,7 +1,7 @@
 import { serve } from '@hono/node-server';
 import type { Hono } from 'hono';
 import { parentPort, workerData } from 'node:worker_threads';
-import { SERVER_DEFAULTS } from '../../server/server-config.js';
+import { parsePort, SERVER_DEFAULTS } from '../../server/server-config.js';
 import { onShutdown } from '../../server/shutdown.js';
 import type { DeployRuntime } from '../contract.js';
 import { fileSystemRuntime } from '../filesystem.js';
@@ -12,12 +12,11 @@ const WILDCARD_HOST = '0.0.0.0';
 /**
  * The address to listen on: an explicit override (the dev server, which picks the port for its worker) beats
  * `PORT` / `HOST`, which beat the built-in default. `??` rather than `||`, so an explicit `PORT=0` — "any free
- * port" — is honoured.
+ * port" — is honoured, and so that {@link parsePort} is never consulted for a port the override already won.
  */
 function listenAddress(overrides?: { port?: number; hostname?: string }): { port: number; hostname: string } {
-  const envPort = process.env.PORT !== undefined ? Number(process.env.PORT) : undefined;
   return {
-    port: overrides?.port ?? envPort ?? SERVER_DEFAULTS.port,
+    port: overrides?.port ?? parsePort(process.env.PORT, 'PORT') ?? SERVER_DEFAULTS.port,
     hostname: overrides?.hostname ?? process.env.HOST ?? SERVER_DEFAULTS.host,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,8 +3,10 @@
  * your pages and endpoints are written against. Nothing here pulls in runtime machinery.
  *
  * Two companion entry points are runtime-only:
- * - `@rshono/core/server` — request context, `redirect`, `notFound`, `onServerError`.
+ * - `@rshono/core/server` — request context, `redirect`, `notFound`, `onServerError`, `publicUrl`.
  * - `@rshono/core/client` — `useNavigation`, `AsyncBoundary`, `CatchBoundary`.
+ *
+ * ESM only: the `exports` map declares `types` and `import` conditions and no `require` one.
  *
  * @example
  * ```ts

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -72,6 +72,13 @@ export interface PageProps<Path extends string = string, E extends Env = Env> {
    * serialized. Passing it to a `'use client'` component fails the render, because it wraps the live
    * request — read what you need here and pass plain values down.
    *
+   * Non-enumerable is the one place this API breaks a JavaScript expectation, and it is unavoidable: an
+   * enumerable `ctx` would put `ctx.hono.env` — every binding and secret — into React's dev-only
+   * serialization of a server component's props, which walks own enumerable properties. So `<Child
+   * {...props} />` hands a **server** child `ctx: undefined` with no error, while the type says otherwise.
+   * Nested server components are meant to call `getRequestContext()` for the same object rather than
+   * receive it, which is also the fix if a spread has already cost you an afternoon.
+   *
    * Reading it on a `render: 'static'` route throws: a prerendered page has no per-request context.
    * Mark the route `render: 'dynamic'`, or use the `url` / `params` props.
    *

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -338,15 +338,16 @@ export interface RouteConfig<TRoutes extends readonly Route[] = readonly Route[]
  * key to check, so it passes. Skipped where the path has no params, because `staticPaths` is not called for
  * such a route at all and an error there would be about the wrong thing.
  */
-type ValidateStaticPaths<R, P extends string> = ParamKeys<P> extends never
-  ? R
-  : R extends { staticPaths: () => infer Sets }
-    ? Awaited<Sets> extends ReadonlyArray<infer Set>
-      ? [keyof PathParams<P>] extends [keyof Set]
-        ? R
-        : R & { staticPaths: `every param set staticPaths returns needs the params of '${P}'` }
-      : R
-    : R;
+type ValidateStaticPaths<R, P extends string> =
+  ParamKeys<P> extends never
+    ? R
+    : R extends { staticPaths: () => infer Sets }
+      ? Awaited<Sets> extends ReadonlyArray<infer Set>
+        ? [keyof PathParams<P>] extends [keyof Set]
+          ? R
+          : R & { staticPaths: `every param set staticPaths returns needs the params of '${P}'` }
+        : R
+      : R;
 
 // `PageProps<P, any>`, not `PageProps<P>`: only the *path* is being checked, and pinning the Env would
 // fail every page that declares its own (`PageProps<'/x', MyEnv>`, to type `ctx.var`).

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -273,13 +273,19 @@ export interface FallbackPage {
 export interface ErrorPageInfo {
   /** The thrown error's message in dev; `'Internal Server Error'` in production. */
   message: string;
-  /** The stack trace. Present in dev only. */
+  /**
+   * The stack trace — **dev only**, and `undefined` in every build. Optional for that reason rather than
+   * because some errors lack one, so a page that renders it should guard on it, not on a mode flag.
+   */
   stack?: string;
 }
 
 /**
  * Props for the `error` page declared in {@link RouteConfig.error} — the usual {@link PageProps} plus
  * the redaction-aware {@link ErrorPageInfo}.
+ *
+ * In a build `error.message` is the generic `'Internal Server Error'` and `error.stack` is `undefined`, so
+ * the page below guards on the stack rather than on a mode flag — there is no mode flag to guard on.
  *
  * @typeParam E - The app's Hono {@link Env}, forwarded to {@link PageProps.ctx}.
  *
@@ -288,7 +294,15 @@ export interface ErrorPageInfo {
  * import type { ErrorPageProps } from '@rshono/core';
  *
  * export default function ServerError({ error }: ErrorPageProps) {
- *   return <html><body><h1>Something went wrong</h1><p>{error.message}</p></body></html>;
+ *   return (
+ *     <html>
+ *       <body>
+ *         <h1>Something went wrong</h1>
+ *         <p>{error.message}</p>
+ *         {error.stack && <pre>{error.stack}</pre>}
+ *       </body>
+ *     </html>
+ *   );
  * }
  * ```
  */

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -308,6 +308,25 @@ export interface RouteConfig<TRoutes extends readonly Route[] = readonly Route[]
   error?: FallbackPage;
 }
 
+/**
+ * The same check for `staticPaths`, whose param sets have to fill the route's own path: a key that does not
+ * is otherwise a build-time throw from `interpolatePath` rather than a type error.
+ *
+ * Keys only, not full assignability, because the declared field type is `Record<string, string>` and a
+ * `staticPaths` annotated as returning exactly that has to stay accepted — an index signature carries no
+ * key to check, so it passes. Skipped where the path has no params, because `staticPaths` is not called for
+ * such a route at all and an error there would be about the wrong thing.
+ */
+type ValidateStaticPaths<R, P extends string> = ParamKeys<P> extends never
+  ? R
+  : R extends { staticPaths: () => infer Sets }
+    ? Awaited<Sets> extends ReadonlyArray<infer Set>
+      ? [keyof PathParams<P>] extends [keyof Set]
+        ? R
+        : R & { staticPaths: `every param set staticPaths returns needs the params of '${P}'` }
+      : R
+    : R;
+
 // `PageProps<P, any>`, not `PageProps<P>`: only the *path* is being checked, and pinning the Env would
 // fail every page that declares its own (`PageProps<'/x', MyEnv>`, to type `ctx.var`).
 type ValidateRoute<R> = R extends {
@@ -316,7 +335,7 @@ type ValidateRoute<R> = R extends {
 }
   ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the Env is deliberately unpinned; see above.
     [PageProps<P, any>] extends [CP]
-    ? R
+    ? ValidateStaticPaths<R, P>
     : R & { component: `component props are not satisfied by PageProps<'${P}'>` }
   : R;
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -210,14 +210,24 @@ export interface EndpointRoute {
    * @see {@link https://hono.dev/docs/api/routing | Hono — routing}
    */
   path: string;
-  /** HTTP method to match. Defaults to `'all'` — every method. */
+  /**
+   * HTTP method to match. Defaults to `'all'` — every method.
+   *
+   * There is no `'head'`: Hono dispatches a `HEAD` as a `GET` and strips the body off the response, so a
+   * `HEAD` is already answered by the `'get'` handler (and by `'all'`), and a route registered for `HEAD`
+   * alone would never be reached.
+   */
   method?: HTTPMethod;
   /** Dynamic import of the {@link EndpointServerModule} exporting `handler`. */
   server: () => Promise<EndpointServerModule>;
 }
 
-/** HTTP methods an {@link EndpointRoute} can match. `'all'` matches every method. */
-export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options' | 'all';
+/**
+ * HTTP methods an {@link EndpointRoute} can match. `'all'` matches every method.
+ *
+ * No `'head'`, deliberately — see {@link EndpointRoute.method}. A `HEAD` reaches the `'get'` handler.
+ */
+export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options' | 'all';
 
 /** Any entry in the `routes` array: a {@link PageRoute} or an {@link EndpointRoute}. */
 export type Route = PageRoute | EndpointRoute;

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -211,13 +211,21 @@ export interface EndpointRoute {
    */
   path: string;
   /**
-   * HTTP method to match. Defaults to `'all'` — every method.
+   * HTTP method to match, or a list of them. Defaults to `'all'` — every method.
    *
    * There is no `'head'`: Hono dispatches a `HEAD` as a `GET` and strips the body off the response, so a
    * `HEAD` is already answered by the `'get'` handler (and by `'all'`), and a route registered for `HEAD`
    * alone would never be reached.
+   *
+   * A list is how a two-method endpoint says so; `'all'` inside one is refused, since it is either the
+   * whole thing or a mistake. A method the route does not name gets Hono's 404 rather than the handler.
+   *
+   * @example
+   * ```ts
+   * { type: 'endpoint', path: '/api/session', method: ['get', 'delete'], server: () => import('./session') }
+   * ```
    */
-  method?: HTTPMethod;
+  method?: HTTPMethod | readonly HTTPMethod[];
   /** Dynamic import of the {@link EndpointServerModule} exporting `handler`. */
   server: () => Promise<EndpointServerModule>;
 }

--- a/packages/core/src/runtime/context.ts
+++ b/packages/core/src/runtime/context.ts
@@ -174,6 +174,14 @@ export type EnvVars<E extends Env> = E['Bindings'] & Record<string, string | und
  * Never construct it yourself. One instance is reused for the whole request, so its lazy getters
  * ({@link RequestContext.url}, {@link RequestContext.env}) are computed at most once.
  *
+ * The eight members that only throw — `redirect`, `notFound`, `json`, `text`, `html`, `body`, `status`,
+ * `header` — are **permanent, and exist to throw**. Every one of them is a silent no-op when reached through
+ * {@link RequestContext.hono} from a page, so a stub that names the thing that does work is the difference
+ * between a message and a page that renders while quietly ignoring half of what it was asked for. They carry
+ * `@deprecated` for the strike-through an editor draws with it, not because they are on the way out: nothing
+ * will un-deprecate or remove them, and dropping them would leave `ctx.redirect('/x')` as
+ * "property does not exist", which says what is wrong and not what to do.
+ *
  * @typeParam E - The Hono {@link Env} describing this app's `Bindings` and `Variables`, so
  *   {@link RequestContext.var} and {@link RequestContext.env} stay typed.
  *
@@ -394,8 +402,9 @@ export class RequestContext<E extends Env = Env> {
   }
 
   // Hono's response builders, restated as errors naming what to use instead — through `ctx.hono` every
-  // one of them is a silent no-op from a page. `@deprecated` strikes them through in autocomplete; the
-  // unread `..._args` is so `ctx.redirect('/x')` reaches the thrown message rather than an arity error.
+  // one of them is a silent no-op from a page. Permanent, deliberately: see the class doc. `@deprecated`
+  // strikes them through in autocomplete; the unread `..._args` is so `ctx.redirect('/x')` reaches the
+  // thrown message rather than an arity error.
 
   /** @deprecated Not available on a page's context — use `redirect()` from `@rshono/core/server`. */
   redirect(..._args: unknown[]): never {

--- a/packages/core/src/runtime/context.ts
+++ b/packages/core/src/runtime/context.ts
@@ -551,18 +551,64 @@ export function notFound(): never {
  */
 export type ServerErrorSource = 'action' | 'render' | 'ssr' | 'request';
 
-/** What an {@link ServerErrorHandler} is told about an error, beyond the error itself. */
-export interface ServerErrorContext {
+/**
+ * What an {@link ServerErrorHandler} is told about an error, beyond the error itself.
+ *
+ * @typeParam E - The app's Hono {@link Env}, to type {@link ServerErrorContext.hono}'s `var` and `env`.
+ */
+export interface ServerErrorContext<E extends Env = Env> {
   /** The stage that produced it — see {@link ServerErrorSource}. */
   source: ServerErrorSource;
   /** The request being served, for the URL, method and headers. */
   request: Request;
+  /**
+   * The Hono {@link Context} for this request — `hono.var` for whatever middleware put there, such as a
+   * request id to correlate the report on, and `hono.env` for a platform that passes bindings.
+   *
+   * Handed over rather than left to {@link getRequestContext}, which a handler cannot reach: an error with
+   * `source: 'request'` is reported from the top-level handler, which runs outside the ambient context.
+   */
+  hono: Context<E>;
+  /**
+   * Holds the invocation open until `promise` settles, where the platform has something to ask.
+   *
+   * Reporting is what this hook exists for, and on a serverless platform a report started here is cut off
+   * the moment the response ends unless something keeps the invocation alive. On Cloudflare Workers that is
+   * `executionCtx.waitUntil`, which this calls. On the `node` and `vercel` targets there is nothing to hold
+   * open — the process outlives the response — so it is a no-op and the report finishes on its own. On
+   * `aws-lambda` it is a no-op as well, because `hono/aws-lambda`'s streaming handler exposes no execution
+   * context to ask; a slow report there is best-effort, so prefer a tracker that batches over one that
+   * round-trips per error.
+   *
+   * A rejection is logged rather than propagated: reporting can never fail a request.
+   */
+  waitUntil: (promise: Promise<unknown>) => void;
 }
 
 /** Handler registered with {@link onServerError}. Called for the side effect; its return value is ignored. */
-export type ServerErrorHandler = (error: unknown, context: ServerErrorContext) => void;
+export type ServerErrorHandler<E extends Env = Env> = (error: unknown, context: ServerErrorContext<E>) => void;
 
 let errorHandler: ServerErrorHandler | undefined;
+
+/**
+ * The platform's "keep this invocation alive" hook, or a no-op where there is none.
+ *
+ * `c.executionCtx` *throws* rather than answering `undefined` where a platform has no execution context, so
+ * a handler that reached for it itself would have its report swallowed by the guard in
+ * {@link reportServerError} — on exactly the platforms where nothing needed holding open.
+ */
+function keepAlive(c: Context, promise: Promise<unknown>): void {
+  // Caught here rather than left to the platform: under `--unhandled-rejections=strict` a rejected report
+  // would end the process, and a failed report must never be worse than no report.
+  const settled = Promise.resolve(promise).catch((error) => {
+    console.error('[rshono] a promise passed to the onServerError waitUntil rejected:', error);
+  });
+  try {
+    c.executionCtx.waitUntil(settled);
+  } catch {
+    // No execution context: nothing here cuts the work off, so there is nothing to hold open.
+  }
+}
 
 /**
  * Errors already forwarded, so one fault is reported once however many stages it crosses.
@@ -581,21 +627,29 @@ const alreadyReported = new WeakSet<object>();
  * Registering again replaces the previous handler. Errors still go to `stderr` either way, and a
  * handler that throws is caught and logged — reporting can never fail a request.
  *
+ * @typeParam E - The app's Hono {@link Env}, to type the `hono` context the handler is given.
+ *
  * @example
  * ```ts
  * // src/server.ts
  * import * as Sentry from '@sentry/node';
  * import { onServerError } from '@rshono/core/server';
  *
- * onServerError((error, { source, request }) => {
- *   Sentry.captureException(error, { tags: { source }, extra: { url: request.url } });
+ * onServerError((error, { source, request, hono, waitUntil }) => {
+ *   // `waitUntil` so a serverless invocation is not frozen before the report is sent.
+ *   waitUntil(
+ *     Sentry.captureException(error, {
+ *       tags: { source, requestId: hono.var.requestId },
+ *       extra: { url: request.url },
+ *     }),
+ *   );
  * });
  * ```
  *
  * @see {@link https://www.rshono.com/docs/hono#error-reporting | Docs — error reporting}
  */
-export function onServerError(handler: ServerErrorHandler): void {
-  errorHandler = handler;
+export function onServerError<E extends Env = Env>(handler: ServerErrorHandler<E>): void {
+  errorHandler = handler as unknown as ServerErrorHandler;
 }
 
 /**
@@ -604,7 +658,7 @@ export function onServerError(handler: ServerErrorHandler): void {
  *
  * @internal
  */
-export function reportServerError(error: unknown, info: ServerErrorContext & { message: string }): void {
+export function reportServerError(error: unknown, info: { source: ServerErrorSource; hono: Context; message: string }): void {
   // The first stage to recognise it wins, since that is the one that knows what it was. A primitive throw
   // cannot be tracked and is reported wherever it is caught.
   if (typeof error === 'object' && error !== null) {
@@ -614,7 +668,14 @@ export function reportServerError(error: unknown, info: ServerErrorContext & { m
   console.error(info.message, error);
   if (!errorHandler) return;
   try {
-    errorHandler(error, { source: info.source, request: info.request });
+    errorHandler(error, {
+      source: info.source,
+      request: info.hono.req.raw,
+      // The handler was registered for the app's own `Env`, which `onServerError` erased to store it; this
+      // puts the context back in the shape it was registered with. Same trade as {@link getRequestContext}.
+      hono: info.hono as Context<Env>,
+      waitUntil: (promise) => keepAlive(info.hono, promise),
+    });
   } catch (handlerError) {
     console.error('[rshono] the onServerError handler threw:', handlerError);
   }

--- a/packages/core/src/runtime/entry.client.tsx
+++ b/packages/core/src/runtime/entry.client.tsx
@@ -114,12 +114,39 @@ function showFatal(error: unknown, componentStack?: string | null): void {
   }, 0);
 }
 
+/** What every flight response is typed as. The charset and any other parameters follow it. */
+const FLIGHT_CONTENT_TYPE = 'text/x-component';
+
+/**
+ * Fetches a payload, refusing a response that is not one.
+ *
+ * The status cannot be the gate: a payload legitimately arrives as a 404 from the `notFound` page and as a
+ * 500 from an action that threw, and both carry a real payload the caller has to see. The content type is.
+ *
+ * What this catches is the response that is not a payload at all — a `bodyLimit()` 413, a proxy's error page,
+ * a 502 mid-deploy. Handed to the flight parser those all surface as `Error: Connection closed.`, with the
+ * status and the body nowhere in sight; here they become an error that says what arrived.
+ */
+async function payloadResponse(request: Request): Promise<Response> {
+  const response = await fetch(request);
+  const contentType = response.headers.get('content-type');
+  if (contentType?.startsWith(FLIGHT_CONTENT_TYPE)) return response;
+  // Read for the message: a plain-text refusal says what it refused only in its body, and HTTP/2 has no
+  // `statusText` at all. Bounded, because this is an error path and the body is not ours to trust.
+  const body = await response.text().then(
+    (text) => text.trim().slice(0, 200),
+    () => '',
+  );
+  const status = `${response.status}${response.statusText ? ` ${response.statusText}` : ''}`;
+  throw new Error(`[rshono] the server answered ${status} (${contentType ?? 'no content type'}) instead of a payload${body ? `: ${body}` : ''}`);
+}
+
 /**
  * Asks a URL for its flight payload. Deliberately uncached — a payload can never be staler than the click
  * that wanted it, and the browser's own HTTP cache is what makes a repeat visit cheap.
  */
 function requestPayload(href: string, signal?: AbortSignal): Promise<RscPayload> {
-  return createFromFetch<RscPayload>(fetch(createRscRequest(new URL(href, location.href).href, undefined, signal)));
+  return createFromFetch<RscPayload>(payloadResponse(createRscRequest(new URL(href, location.href).href, undefined, signal)));
 }
 
 /**
@@ -363,7 +390,7 @@ async function main() {
     });
     let payload: RscPayload;
     try {
-      payload = await createFromFetch<RscPayload>(fetch(request), { temporaryReferences });
+      payload = await createFromFetch<RscPayload>(payloadResponse(request), { temporaryReferences });
     } catch (error) {
       if (handleControlDigest(error)) return undefined;
       throw error;
@@ -374,7 +401,14 @@ async function main() {
     }
     if (documentUrl() === calledFrom) React.startTransition(() => void setPayload(payload));
     if (payload.notFound) return undefined;
-    const result = payload.returnValue!;
+    const result = payload.returnValue;
+    if (!result) {
+      // A payload that is not this action's own reply: the server rendered a page in its place. An action
+      // that had already run has its result carried across (see `actionResults` in entry.rsc.tsx), so
+      // reaching here means the request failed before it ran at all — an undecodable body, most likely.
+      // Reading `.ok` off it used to hand the caller `Cannot read properties of undefined`.
+      throw new Error('[rshono] the server action produced no result — the request failed around it and the server answered with a page instead. Its log has the error.');
+    }
     if (!result.ok) throw result.error;
     return result.value;
   });

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -371,8 +371,7 @@ function buildApp(): Hono {
 
   // A floor, not a policy: an app wanting the full set registers `secureHeaders()` in src/server.ts, and
   // because this is registered first it unwinds last, so the "only if unset" checks stand aside for it.
-  // Owned by the framework because it also has to cover `mountStaticAssets` — a terminal handler the
-  // app's own middleware never sees.
+  // Owned by the framework so that an app with no src/server.ts at all still gets it.
   app.use(async (c, next) => {
     await next();
     const headers = c.res.headers;
@@ -397,13 +396,18 @@ function buildApp(): Hono {
     if (!headers.has('cache-control')) headers.set('cache-control', 'private, no-cache');
   });
 
-  runtime.mountStaticAssets(app);
-
-  // Ahead of the page routes, so the app's own middleware (`csrf()`, `bodyLimit()`, auth, logging) wraps
-  // page requests too. The flip side: a *terminal* handler in src/server.ts shadows a page at the same path.
+  // First, so the app's own middleware (`csrf()`, `bodyLimit()`, auth, logging) wraps everything registered
+  // below: the page routes, and the asset handlers too. Assets used to be mounted ahead of this, which left
+  // `/_static/*` answered by a terminal handler nothing of the app's ever saw — no `secureHeaders()`, and so
+  // no HSTS on exactly the requests a downgrade attack lands on. The flip side is the same one it always had,
+  // one path wider: a *terminal* handler in src/server.ts shadows a page at the same path, and unscoped
+  // middleware now also runs for `/_static`, which is a reserved prefix an app should not be matching on
+  // purpose anyway.
   if (serverApp) {
     app.route('/', serverApp);
   }
+
+  runtime.mountStaticAssets(app);
 
   const memoizePage = (page: FallbackPage, label: string) => once(() => loadPageModule(page.component, label));
   const loadNotFoundPage = routeConfig.notFound ? memoizePage(routeConfig.notFound, 'the notFound page') : null;

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -194,6 +194,39 @@ function releaseWhenDone(stream: ReadableStream<Uint8Array>, done: () => void): 
   );
 }
 
+/**
+ * A macrotask boundary: `setImmediate` where there is one — the current turn's check phase rather than a
+ * timer — and `setTimeout` as the portable fallback, for a runtime without it. `flight-inject.ts` has the
+ * same two lines and the same reason; they are not shared because that module belongs to the SSR layer, and
+ * importing it here would give the RSC layer its own instance of it.
+ */
+const deferTask: (run: () => void) => void =
+  typeof setImmediate === 'function'
+    ? setImmediate
+    : (run) => {
+        setTimeout(run, 0);
+      };
+
+/**
+ * Dev-only: says that a control signal arrived too late to be one.
+ *
+ * The root fix is in app code, so authoring time is where this has to be said, and a docs paragraph is not
+ * where anyone reads it. `isDev` is the baked build flag, so a production server pays one boolean check on a
+ * path that has already gone wrong — and says nothing.
+ */
+function warnLateControlSignal(c: Context, signal: ControlSignal): void {
+  const isRedirect = signal instanceof RedirectSignal;
+  console.warn(
+    `[rshono] ${isRedirect ? `redirect(${JSON.stringify(signal.location)})` : 'notFound()'} was called from a boundary that ` +
+      `resolved after the page shell had already been sent (${c.req.method} ${c.req.path}), so it cannot become a real ` +
+      `${isRedirect ? '3xx' : '404'}: the response is committed as 200 text/html. A browser with JavaScript follows the ` +
+      `digest that rides the payload; one without stays on the Suspense fallback, and a crawler indexes the 200.${
+        isRedirect ? '' : ' A JavaScript client recovers by reloading, which renders this same page again.'
+      }` +
+      ' Decide before the render starts streaming — in Hono middleware, or in the page component body above the boundary.',
+  );
+}
+
 interface ComponentRenderOptions {
   status?: number;
   isRsc: boolean;
@@ -265,12 +298,31 @@ async function renderComponent(c: Context, Page: ServerEntry<PageComponent>, opt
   beginPageRender(c);
 
   let controlSignal: ControlSignal | undefined;
+  /** Set once `renderHTML` has returned, which is where the response head stops being changeable. */
+  let shellFlushed = false;
   const rscStream = renderToReadableStream(rscPayload, {
     temporaryReferences: opts.temporaryReferences,
     signal,
     onError(error) {
       if (isControlSignal(error)) {
         controlSignal = error;
+        if (shellFlushed) {
+          if (isDev) warnLateControlSignal(c, error);
+          // Past the shell the status line, the headers and the first bytes are on the wire, so the digest
+          // React writes into the payload is the only path left — and everything still rendering is for a
+          // page the browser is about to navigate away from. Winding it down stops those boundaries, runs
+          // `flight-inject`'s cancel/flush, and fires the `release()` above now rather than whenever the
+          // doomed render happens to finish.
+          //
+          // One macrotask later rather than from inside `onError`, where React is still handling the error
+          // that produced the digest — the row carrying it is the only recovery the client has, and an abort
+          // that re-entered React there could cut the render off before it is written. Measured to survive
+          // either way on react-server-dom-rspack 0.1.0; deferred anyway, because that ordering is an
+          // internal the `^19.1.0` peer range does not promise, and the cost is one macrotask on a render
+          // that is already doomed. The reason is the signal itself, so every boundary the abort errors
+          // carries the digest rather than a bare AbortError the client would paint as a fault.
+          if (!signal.aborted) deferTask(() => renderAbort.abort(error));
+        }
         return error.digest;
       }
       if (!signal.aborted) reportServerError(error, { source: 'render', request: c.req.raw, message: '[rshono] render error:' });
@@ -299,6 +351,10 @@ async function renderComponent(c: Context, Page: ServerEntry<PageComponent>, opt
     if (controlSignal) throw controlSignal;
     throw error;
   }
+  // `renderHTML` returns at *shell ready*, so from here the response is the one that ships. Set before the
+  // check below rather than after it, so nothing lands in the window between the two: a signal that arrives
+  // in it is handled there *and* schedules an abort, and aborting an aborted controller is a no-op.
+  shellFlushed = true;
   if (controlSignal) {
     // The shell resolved, so this response is live: React is being pumped into the payload-injecting
     // transform, and a `redirect()` that surfaced from a boundary settling just before the shell was ready

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -43,7 +43,24 @@ const serverApp = validateServerApp(serverAppModule);
 // Compiled into the bundle from rshono.config.ts by DefinePlugin; there is no runtime env-var interface.
 const { isDev } = __RSHONO_CONFIG__;
 
-/** How long a prerendered page may be reused before revalidating. Also what `public/` files get. */
+/**
+ * How long a prerendered page may be reused before revalidating. Also what `public/` files get.
+ *
+ * Not a config field, deliberately: it is a per-response header, and `rshono.config.ts` is compiled into the
+ * bundle — a cache policy you cannot change without a rebuild is the wrong shape. An app that wants a longer
+ * `max-age`, or a `stale-while-revalidate`, sets it from middleware **after `await next()`**:
+ *
+ * ```ts
+ * server.use('/docs/*', async (c, next) => {
+ *   await next();
+ *   c.res.headers.set('cache-control', 'public, max-age=86400, stale-while-revalidate=604800');
+ * });
+ * ```
+ *
+ * After, because the response below is built with `cache-control` in the bag it hands `c.body(...)`, and
+ * that replaces a header prepared with `c.header(...)` before the handler ran. The `ETag` is untouched
+ * either way, so revalidation still costs a 304 rather than the page.
+ */
 const SSG_CACHE_CONTROL = 'public, max-age=300';
 
 /**

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -68,6 +68,20 @@ export type RscPayload = {
 };
 
 /**
+ * The result of an action that has already run, for the request whose *render* then failed.
+ *
+ * The action and the page it answers with are one response: an action returns its value through the payload
+ * of the page rendered after it. So when that render throws — a page module that will not load, most
+ * plausibly a chunk that went away mid-deploy — `onError` renders the `error` page in its place, and without
+ * this the reply carries no `returnValue` at all. The caller of an action that ran, and may well have
+ * written something, would be told only that a field was missing.
+ *
+ * Keyed on the Hono context the way `beginPageRender` keys its own marker, and weakly, so nothing outlives
+ * the request it belongs to.
+ */
+const actionResults = new WeakMap<Context, ActionResult>();
+
+/**
  * The per-request CSP nonce, if the app asked for one.
  *
  * The framework never mints it: `secureHeaders()` does, when its policy contains the `NONCE`
@@ -336,6 +350,9 @@ async function renderPage(c: Context, loadPage: () => Promise<ServerEntry<PageCo
         returnValue = { ok: false, error };
         actionStatus = 500;
       }
+      // The action is done and its result is the caller's, whatever becomes of the render below. See
+      // {@link actionResults}.
+      actionResults.set(c, returnValue);
     } else {
       // A `<form action={serverAction}>` post, which is the path that runs before hydration and with
       // JavaScript off. Unlike the client-initiated one it carries no custom header, so it is also the only
@@ -522,7 +539,9 @@ function buildApp(): Hono {
           }
         : { message: 'Internal Server Error' };
       try {
-        return await runWithContext(c, async () => renderComponent(c, await loadErrorPage(), { status: 500, isRsc, errorInfo }));
+        return await runWithContext(c, async () =>
+          renderComponent(c, await loadErrorPage(), { status: 500, isRsc, errorInfo, returnValue: actionResults.get(c) }),
+        );
       } catch (renderError) {
         reportServerError(renderError, { source: 'request', request: c.req.raw, message: '[rshono] the error page failed to render:' });
       }

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -599,9 +599,17 @@ function buildApp(): Hono {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return endpointHandler(c, next);
       };
-      const method = route.method ?? 'all';
-      if (method === 'all') app.all(route.path, handler);
-      else app.on(method.toUpperCase(), route.path, handler);
+      // De-duplicated, because `app.on(['GET', 'GET'], …)` registers the path twice. Validation refuses
+      // `'all'` inside a list, so a list that reaches here is concrete methods only.
+      const methods = [...new Set([route.method ?? 'all'].flat())];
+      if (methods.includes('all')) app.all(route.path, handler);
+      else {
+        app.on(
+          methods.map((method) => method.toUpperCase()),
+          route.path,
+          handler,
+        );
+      }
     }
   }
 

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -94,20 +94,25 @@ function cspNonce(c: Context): string | undefined {
  *
  * Both halves are required, because either alone refuses something real:
  *
- * - `Sec-Fetch-Site: cross-site` is the browser's own statement of provenance, and every browser that can post
- *   a form to a server action sends it. An absent header means a non-browser client, which cannot be a CSRF
- *   victim; `same-site` is left alone too, since a subdomain policy is `csrf()`'s to express.
- * - An `Origin` that is the app's own contradicts that label — a browser calls a post from the app's own pages
+ * - `Sec-Fetch-Site` is the browser's own statement of provenance, unforgeable by page script, and every
+ *   browser that can post a form to a server action sends it. `cross-site` and `same-site` are the two labels
+ *   that mean "not from this origin" — `same-site` is what a *sibling subdomain* gets, which is a user-content
+ *   host, a stale CNAME or a subdomain takeover, so leaving it to `csrf()` meant an app without one could have
+ *   any `'use server'` export driven from next door. An absent header means a non-browser client, which cannot
+ *   be a CSRF victim. `same-origin` and `none` settle it on their own, and are what a genuine post carries
+ *   however many proxies rewrote `Host` on the way in.
+ * - An `Origin` that is the app's own contradicts either label — a browser calls a post from the app's own pages
  *   `same-origin` — so the pair is a shape no browser produces, and refusing it would only catch a proxy or a
  *   test client setting the label by hand while posting from the app itself.
  *
  * `publicUrl(c)` rather than `c.req.url`, so it honours `trustProxy` and compares against the origin the
  * browser actually used — which behind a proxy, `rshono dev`'s included, is not the one the server was reached
- * on. The cost is that an app deliberately accepting cross-site *form* posts to an action cannot; that is what
- * an `{ type: 'endpoint' }` route is for.
+ * on. The cost is that an app deliberately accepting *form* posts to an action from another origin of its own
+ * cannot, `csrf()`'s allowlist included; that is what an `{ type: 'endpoint' }` route is for.
  */
 function refusesCrossSiteForm(c: Context): boolean {
-  if (c.req.header('sec-fetch-site') !== 'cross-site') return false;
+  const site = c.req.header('sec-fetch-site');
+  if (site !== 'cross-site' && site !== 'same-site') return false;
   const origin = c.req.header('origin');
   return origin !== undefined && origin !== publicUrl(c).origin;
 }

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -27,7 +27,7 @@ import { runtime } from '@rshono/deploy';
 import { routes as userRoutes } from '@rshono/routes';
 // @ts-expect-error — resolved by the '@rshono/server-app' alias (src/server.ts or the empty fallback)
 import * as serverAppModule from '@rshono/server-app';
-import { isPageRoute, type ErrorPageInfo, type FallbackPage, type PageComponent, type PageProps, type Route, type RouteConfig } from '../router.js';
+import { isPageRoute, type ErrorPageInfo, type FallbackPage, type PageComponent, type PageProps, type Route } from '../router.js';
 import { appendVary, etagMatches } from '../server/headers.js';
 import { beginPageRender, getRequestContext, publicUrl, readParams, reportServerError, runWithContext } from './context.js';
 import { isControlSignal, RedirectSignal, type ControlSignal } from './control.js';
@@ -36,8 +36,9 @@ import { renderHTML } from './entry.ssr.js';
 import type { CancellableTransformer } from './flight-inject.js';
 import { RouterProvider } from './navigation.js';
 import { asksForRsc, isActionRequest, parseRenderRequest, requestWantsRsc, RSC_VARY_HEADER, wantsRsc } from './request.js';
+import { validateRoutesModule, validateServerApp } from './validate-entries.js';
 
-const serverApp = ((serverAppModule as { default?: unknown }).default ?? null) as Hono | null;
+const serverApp = validateServerApp(serverAppModule);
 
 // Compiled into the bundle from rshono.config.ts by DefinePlugin; there is no runtime env-var interface.
 const { isDev } = __RSHONO_CONFIG__;
@@ -50,7 +51,9 @@ const PAGE_CONTENT_TYPE = /^(?:text\/html|text\/x-component)\b/;
 
 runtime.loadEnv();
 
-const routeConfig = userRoutes as RouteConfig;
+// Checked rather than cast: these two modules are the app's, and a mistake in either used to surface as a
+// `TypeError` from somewhere else entirely — or, for a duplicated path, as nothing at all.
+const routeConfig = validateRoutesModule(userRoutes);
 export const routes: readonly Route[] = routeConfig.routes;
 
 /** The result of a server action, as a `Result<T, E>` rather than an `ok` flag over one field. */

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -46,6 +46,13 @@ const { isDev } = __RSHONO_CONFIG__;
 /** How long a prerendered page may be reused before revalidating. Also what `public/` files get. */
 const SSG_CACHE_CONTROL = 'public, max-age=300';
 
+/**
+ * What a page response gets when nothing else set one: without it a shared cache is free to store a logged-in
+ * user's page and hand it to someone else. `private, no-cache` forbids that without blocking bfcache, which
+ * `no-store` would.
+ */
+const PAGE_CACHE_CONTROL = 'private, no-cache';
+
 /** The two content types a page can be served as, from the same URL — which is what makes `Vary` non-optional. */
 const PAGE_CONTENT_TYPE = /^(?:text\/html|text\/x-component)\b/;
 
@@ -161,7 +168,11 @@ function acceptsHtml(c: Context): boolean {
  * payload. It carries the `Vary` too: this is one of the answers a page URL gives depending on the `RSC` request header.
  */
 function plainNotFound(c: Context): Response {
-  return c.text('Not Found', 404, { vary: RSC_VARY_HEADER });
+  // `cache-control` explicitly, because the default above is applied to page *content types* and this is
+  // `text/plain`. A 404 is heuristically cacheable under RFC 9111, so without it a shared cache may store
+  // this one — while the rendered HTML 404 next to it, the same answer to the same request from a client
+  // that asked for HTML, is correctly private.
+  return c.text('Not Found', 404, { vary: RSC_VARY_HEADER, 'cache-control': PAGE_CACHE_CONTROL });
 }
 
 /** A lazy once-cell: runs `load` at most once, but clears a rejection so a later call can retry. */
@@ -472,9 +483,7 @@ function buildApp(): Hono {
     // Page responses only from here down.
     if (!PAGE_CONTENT_TYPE.test(headers.get('content-type') ?? '')) return;
     appendVary(headers, RSC_VARY_HEADER);
-    // Without a default a shared cache is free to store a logged-in user's page and hand it to someone
-    // else. `private, no-cache` forbids that without blocking bfcache, which `no-store` would.
-    if (!headers.has('cache-control')) headers.set('cache-control', 'private, no-cache');
+    if (!headers.has('cache-control')) headers.set('cache-control', PAGE_CACHE_CONTROL);
   });
 
   // First, so the app's own middleware (`csrf()`, `bodyLimit()`, auth, logging) wraps everything registered
@@ -635,7 +644,9 @@ function buildApp(): Hono {
       }
     }
     const detail = isDev ? `\n\n${error instanceof Error ? (error.stack ?? error.message) : String(error)}` : '';
-    return c.text(`Internal Server Error${detail}`, 500, { vary: RSC_VARY_HEADER });
+    // Same reason as `plainNotFound`, minus the urgency: a 500 is not heuristically cacheable, so this half
+    // is consistency — the framework's own answers should not differ in what they promise about caching.
+    return c.text(`Internal Server Error${detail}`, 500, { vary: RSC_VARY_HEADER, 'cache-control': PAGE_CACHE_CONTROL });
   });
 
   return app;

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -336,7 +336,7 @@ async function renderComponent(c: Context, Page: ServerEntry<PageComponent>, opt
         }
         return error.digest;
       }
-      if (!signal.aborted) reportServerError(error, { source: 'render', request: c.req.raw, message: '[rshono] render error:' });
+      if (!signal.aborted) reportServerError(error, { source: 'render', hono: c, message: '[rshono] render error:' });
     },
   });
 
@@ -354,8 +354,8 @@ async function renderComponent(c: Context, Page: ServerEntry<PageComponent>, opt
       signal,
       nonce,
       onDone: release,
-      onShellError: (error) => reportServerError(error, { source: 'ssr', request: c.req.raw, message: '[rshono] SSR shell error:' }),
-      onError: (error) => reportServerError(error, { source: 'ssr', request: c.req.raw, message: '[rshono] SSR error:' }),
+      onShellError: (error) => reportServerError(error, { source: 'ssr', hono: c, message: '[rshono] SSR shell error:' }),
+      onError: (error) => reportServerError(error, { source: 'ssr', hono: c, message: '[rshono] SSR error:' }),
     });
   } catch (error) {
     release();
@@ -413,7 +413,7 @@ async function renderPage(c: Context, loadPage: () => Promise<ServerEntry<PageCo
         if (isControlSignal(error)) throw error;
         // In production React sends a thrown action error to the client as an opaque marker, so this is
         // the only place the real one is visible.
-        reportServerError(error, { source: 'action', request, message: '[rshono] server action error:' });
+        reportServerError(error, { source: 'action', hono: c, message: '[rshono] server action error:' });
         returnValue = { ok: false, error };
         actionStatus = 500;
       }
@@ -440,7 +440,7 @@ async function renderPage(c: Context, loadPage: () => Promise<ServerEntry<PageCo
           // because this path has no client boundary and no `useActionState` to hand the error to, so the
           // app's `error` page is the honest answer. `reportServerError` de-duplicates, so the re-throw
           // reaching `onError` does not report it a second time.
-          reportServerError(error, { source: 'action', request, message: '[rshono] server action error:' });
+          reportServerError(error, { source: 'action', hono: c, message: '[rshono] server action error:' });
           throw error;
         }
         formState = (await decodeFormState(result, formData, __rspack_rsc_manifest__.serverManifest)) ?? undefined;
@@ -528,7 +528,7 @@ function buildApp(): Hono {
         // fail, and this is what the same page does when `app.notFound` renders it — so it is honoured, and
         // recurses exactly once.
         if (error instanceof RedirectSignal) return respondToControlSignal(c, error);
-        reportServerError(error, { source: 'render', request: c.req.raw, message: '[rshono] the notFound page failed to render:' });
+        reportServerError(error, { source: 'render', hono: c, message: '[rshono] the notFound page failed to render:' });
       }
     }
     return plainNotFound(c);
@@ -629,7 +629,7 @@ function buildApp(): Hono {
       const res = error.getResponse();
       return c.newResponse(res.body, res);
     }
-    reportServerError(error, { source: 'request', request: c.req.raw, message: '[rshono] request error:' });
+    reportServerError(error, { source: 'request', hono: c, message: '[rshono] request error:' });
     const isRsc = requestWantsRsc(c.req.raw);
     if (loadErrorPage && (isRsc || acceptsHtml(c))) {
       const errorInfo: ErrorPageInfo = isDev
@@ -643,7 +643,7 @@ function buildApp(): Hono {
           renderComponent(c, await loadErrorPage(), { status: 500, isRsc, errorInfo, returnValue: actionResults.get(c) }),
         );
       } catch (renderError) {
-        reportServerError(renderError, { source: 'request', request: c.req.raw, message: '[rshono] the error page failed to render:' });
+        reportServerError(renderError, { source: 'request', hono: c, message: '[rshono] the error page failed to render:' });
       }
     }
     const detail = isDev ? `\n\n${error instanceof Error ? (error.stack ?? error.message) : String(error)}` : '';

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -610,7 +610,10 @@ function buildApp(): Hono {
   app.notFound(async (c) => {
     const isRsc = requestWantsRsc(c.req.raw);
     if (loadNotFoundPage && (isRsc || acceptsHtml(c))) {
-      return runWithContext(c, async () => renderComponent(c, await loadNotFoundPage(), { status: 404, isRsc }));
+      // `notFound: true` here as well as on the signal path: the two produce the same page for the same
+      // status, and a payload that says so from one route and not the other is a wire contract with a hole
+      // in it. The client reads it to tell "this is the 404 page" from "this is the page you asked for".
+      return runWithContext(c, async () => renderComponent(c, await loadNotFoundPage(), { status: 404, isRsc, notFound: true }));
     }
     return plainNotFound(c);
   });

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -531,9 +531,12 @@ function buildApp(): Hono {
       const servesPrerendered = !isDev && route.render === 'static';
       const loadPage = once(() => loadPageModule(route.component, `"${route.path}"`));
 
-      const handler: Handler = async (c) => {
+      /** Everything the route answers, before a HEAD has its body taken off it. */
+      const respond = async (c: Context): Promise<Response> => {
         try {
-          if (servesPrerendered && c.req.method === 'GET') {
+          // A HEAD takes the GET path, prerendered bytes included: the headers it promises are the ones a
+          // GET would send, `etag` and `content-length` among them.
+          if (servesPrerendered && (c.req.method === 'GET' || c.req.method === 'HEAD')) {
             const isRsc = asksForRsc(c.req.raw);
             // One fixed set of bytes cannot carry a per-request nonce, so a document has to be rendered
             // where the app's CSP has one. Decided per request, so an app whose policy carries no `NONCE`
@@ -561,6 +564,21 @@ function buildApp(): Hono {
           if (isControlSignal(error)) return runWithContext(c, () => respondToControlSignal(c, error));
           throw error;
         }
+      };
+
+      const handler: Handler = async (c) => {
+        const response = await respond(c);
+        // Hono dispatches a HEAD to the GET route and then rebuilds the response as `new Response(null, res)`,
+        // which drops the body without reading it — so for a rendered page nothing ever consumes the stream:
+        // `flight-inject`'s `cancel` never runs, and neither does the `release()` that detaches the abort
+        // forwarder from the request signal. Cancelling here is what ends the render nobody asked to read.
+        if (c.req.method === 'HEAD' && response.body !== null) {
+          void response.body.cancel().catch(() => {
+            // Already errored or locked, and there is nothing left to release either way.
+          });
+          return new Response(null, response);
+        }
+        return response;
       };
       app.on(['GET', 'POST'], route.path, handler);
     } else {

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -450,7 +450,21 @@ function buildApp(): Hono {
       return c.redirect(signal.location, signal.status as RedirectStatusCode);
     }
     if (loadNotFoundPage) {
-      return renderComponent(c, await loadNotFoundPage(), { status: 404, isRsc, notFound: true });
+      try {
+        return await renderComponent(c, await loadNotFoundPage(), { status: 404, isRsc, notFound: true });
+      } catch (error) {
+        // The `notFound` page is already the answer to a request that went wrong, so a failure here has
+        // nowhere to escalate to: this runs from `onError` as well as from the page handler, and Hono calls
+        // `onError` inside its own catch — a throw from there rejects `app.fetch`, which
+        // `@hono/node-server` turns into a bodiless 500 with nothing in the log. So it is answered here, the
+        // way a failing `error` page is answered below.
+        //
+        // A `redirect()` from the page is the exception: nothing is committed yet, the branch above cannot
+        // fail, and this is what the same page does when `app.notFound` renders it — so it is honoured, and
+        // recurses exactly once.
+        if (error instanceof RedirectSignal) return respondToControlSignal(c, error);
+        reportServerError(error, { source: 'render', request: c.req.raw, message: '[rshono] the notFound page failed to render:' });
+      }
     }
     return plainNotFound(c);
   };

--- a/packages/core/src/runtime/entry.rsc.tsx
+++ b/packages/core/src/runtime/entry.rsc.tsx
@@ -103,7 +103,11 @@ function cspNonce(c: Context): string | undefined {
  *   however many proxies rewrote `Host` on the way in.
  * - An `Origin` that is the app's own contradicts either label — a browser calls a post from the app's own pages
  *   `same-origin` — so the pair is a shape no browser produces, and refusing it would only catch a proxy or a
- *   test client setting the label by hand while posting from the app itself.
+ *   test client setting the label by hand while posting from the app itself. Nothing else clears the label:
+ *   an `Origin` of `null` (a sandboxed iframe, a `data:` URL, `Referrer-Policy: no-referrer`) and no `Origin`
+ *   at all are both refused. A browser attaches one to every non-GET request, so neither is a shape it
+ *   produces — but a security predicate that says "not proven foreign" rather than "proven local" fails open
+ *   the day something does produce it.
  *
  * `publicUrl(c)` rather than `c.req.url`, so it honours `trustProxy` and compares against the origin the
  * browser actually used — which behind a proxy, `rshono dev`'s included, is not the one the server was reached
@@ -113,8 +117,7 @@ function cspNonce(c: Context): string | undefined {
 function refusesCrossSiteForm(c: Context): boolean {
   const site = c.req.header('sec-fetch-site');
   if (site !== 'cross-site' && site !== 'same-site') return false;
-  const origin = c.req.header('origin');
-  return origin !== undefined && origin !== publicUrl(c).origin;
+  return c.req.header('origin') !== publicUrl(c).origin;
 }
 
 async function loadPageModule(load: () => Promise<{ default: PageComponent }>, label: string): Promise<ServerEntry<PageComponent>> {

--- a/packages/core/src/runtime/flight-inject.ts
+++ b/packages/core/src/runtime/flight-inject.ts
@@ -142,13 +142,19 @@ export function injectFlightPayload(
    * The wrapper readable this function returns is the missing signal: its `pull` runs exactly when the
    * consumer wants another chunk, and releases one permit. Both producers — the HTML batcher and the payload
    * pump — take one before they enqueue, so a stalled client parks React instead of filling the process. The
-   * Streams standard calls `pull` again only once the previous call has settled, so at most one permit is ever
-   * outstanding, which bounds the queue at a chunk.
+   * Streams standard calls `pull` again only once the previous call has settled, and a call only settles once
+   * a chunk has arrived, so permits are handed out one at a time and the queue is bounded at a chunk.
    *
    * What is left buffered is one React flush, because a flush has to leave here as a single chunk (see
    * {@link emitBatch}) — the same bound React itself holds while it builds one. The two enqueues in `flush`
    * are ungated for a related reason: the response is over by then, and parking its last two chunks on a
-   * permit would only add a way for it not to end.
+   * permit would only add a way for it not to end. They are also why the count can reach two at the very
+   * end — an ungated enqueue settles a pull without spending its permit — which is harmless, there being
+   * nothing left to produce.
+   *
+   * The cost is one extra stream hop and a microtask per chunk: 3.6ms → 4.0ms to push a 187 kB page through
+   * this module with nothing else in the way, which is not the shape of a real response, where the socket
+   * dominates by orders of magnitude.
    */
   let permits = 0;
   const waiting: Array<() => void> = [];

--- a/packages/core/src/runtime/flight-inject.ts
+++ b/packages/core/src/runtime/flight-inject.ts
@@ -65,12 +65,26 @@ function endsWithTrailer(buffer: Uint8Array, length: number): boolean {
   return true;
 }
 
+/**
+ * The characters a CSP nonce may be made of: base64 and base64url, which is what every generator of one emits
+ * — Hono's `secureHeaders()`, the only source the framework reads, produces base64 of 16 random bytes.
+ *
+ * The tag below is built by hand rather than by React, so this is the one attribute value in a rendered
+ * document that nothing else escapes. The value is not attacker-controlled today, but the framework does not
+ * own where it comes from: `c.get('secureHeadersNonce')` is an ordinary context variable that any middleware
+ * can set, and a nonce carrying a `"` would close the attribute and open a script-injection point in the
+ * document. Anything outside this set is dropped rather than escaped: a value this is not is not a nonce, and
+ * a page whose payload scripts are then refused by the policy is the visible failure to have.
+ */
+const NONCE_CHARS = /^[A-Za-z0-9+/=_-]+$/;
+
 export function injectFlightPayload(
   rscStream: ReadableStream<Uint8Array>,
   options: { nonce?: string; onDone?: () => void } = {},
 ): TransformStream<Uint8Array, Uint8Array> {
   const { nonce, onDone } = options;
-  const scriptOpen = `<script${nonce ? ` nonce="${nonce}"` : ''}>(self.__FLIGHT_DATA||=[]).push(`;
+  const safeNonce = nonce !== undefined && NONCE_CHARS.test(nonce) ? nonce : undefined;
+  const scriptOpen = `<script${safeNonce ? ` nonce="${safeNonce}"` : ''}>(self.__FLIGHT_DATA||=[]).push(`;
   const scriptClose = ')</script>';
 
   const { promise: flightWritten, resolve: flightDone } = Promise.withResolvers<void>();

--- a/packages/core/src/runtime/flight-inject.ts
+++ b/packages/core/src/runtime/flight-inject.ts
@@ -66,6 +66,23 @@ function endsWithTrailer(buffer: Uint8Array, length: number): boolean {
 }
 
 /**
+ * How many of `buffer`'s last bytes could still turn into the document trailer — the length of the longest
+ * suffix of `buffer[0..length)` that is a prefix of it, `TRAILER_BYTES.length` for the whole thing.
+ *
+ * At most 14 bytes are ever held back, and in practice 0: a React flush ends with a closed tag, not with the
+ * start of one. Cheaper than it looks, too — the first comparison rejects every suffix whose first byte is
+ * not `<`.
+ */
+function trailerPrefixLength(buffer: Uint8Array, length: number): number {
+  candidate: for (let take = Math.min(length, TRAILER_BYTES.length); take > 0; take--) {
+    const from = length - take;
+    for (let i = 0; i < take; i++) if (buffer[from + i] !== TRAILER_BYTES[i]) continue candidate;
+    return take;
+  }
+  return 0;
+}
+
+/**
  * The characters a CSP nonce may be made of: base64 and base64url, which is what every generator of one emits
  * — Hono's `secureHeaders()`, the only source the framework reads, produces base64 of 16 random bytes.
  *
@@ -93,6 +110,11 @@ export function injectFlightPayload(
 
   const batch: Uint8Array[] = [];
   let boundary: TaskHandle | null = null;
+  /**
+   * The tail of the last batch that could still be the start of the document trailer, carried into the next
+   * one. See {@link emitBatch}.
+   */
+  let carry: Uint8Array | null = null;
 
   /**
    * Set once the consumer has gone away, so nothing tries to enqueue into a readable that cannot take it.
@@ -171,6 +193,7 @@ export function injectFlightPayload(
       boundary = null;
     }
     batch.length = 0;
+    carry = null;
     for (const resolve of waiting.splice(0)) resolve();
     // Otherwise the teed RSC branch keeps being pumped for a response nobody will read, and the tee's
     // other half buffers every chunk waiting for this one to catch up.
@@ -181,16 +204,24 @@ export function injectFlightPayload(
   }
 
   /**
-   * Emits the HTML buffered since the last boundary, holding back the document trailer for
-   * {@link TransformStream.flush} to re-emit after the payload scripts.
+   * Emits the HTML buffered since the last boundary, holding back the document trailer for `flush` to re-emit
+   * after the payload scripts.
    *
-   * The batch is joined before the trailer is looked for, so one React split across two views is still
-   * found. React writes its final flush in one synchronous run, so a trailer split across *batches* is not
-   * a shape it produces.
+   * The batch is joined before the trailer is looked for, so one React split across two views is still found.
+   * A trailer split across two *batches* is not a shape React produces — it writes its final flush in one
+   * synchronous run — but this injector exists because `rsc-html-stream` made a narrower version of that same
+   * assumption and was wrong (see the module header), so anything that could still become a trailer is held
+   * back in {@link carry} rather than assumed not to be. Only `final`, the call from `flush`, may emit such a
+   * tail: by then there is no next batch for it to complete.
+   *
+   * A tail that never does complete therefore leaves after the payload scripts rather than before them, which
+   * is the deliberate half of the trade: releasing it the moment a script wants to go out is the very bug this
+   * guards, because the next batch may be the rest of the trailer. It costs at most 13 bytes of a truncated
+   * document arriving late, still inside `<body>`.
    */
-  function emitBatch(controller: TransformStreamDefaultController<Uint8Array>): void {
+  function emitBatch(controller: TransformStreamDefaultController<Uint8Array>, final = false): void {
     boundary = null;
-    let total = 0;
+    let total = carry?.byteLength ?? 0;
     for (const chunk of batch) total += chunk.byteLength;
     if (total === 0) {
       batch.length = 0;
@@ -199,13 +230,21 @@ export function injectFlightPayload(
 
     const joined = new Uint8Array(total);
     let at = 0;
+    if (carry) {
+      joined.set(carry, at);
+      at += carry.byteLength;
+      carry = null;
+    }
     for (const chunk of batch) {
       joined.set(chunk, at);
       at += chunk.byteLength;
     }
     batch.length = 0;
 
-    const end = endsWithTrailer(joined, total) ? total - TRAILER_BYTES.length : total;
+    const held = final ? (endsWithTrailer(joined, total) ? TRAILER_BYTES.length : 0) : trailerPrefixLength(joined, total);
+    const end = total - held;
+    // Copied rather than a `subarray`, which would keep the whole joined flush alive for 14 bytes.
+    if (held > 0 && !final) carry = joined.slice(end);
     if (end > 0) controller.enqueue(joined.subarray(0, end));
   }
 
@@ -287,12 +326,10 @@ export function injectFlightPayload(
     async flush(controller) {
       // Both of these have to happen *before* the await, and in this order.
       try {
-        // Anything still batched belongs ahead of the payload scripts, which sit at the end of `<body>`.
-        if (boundary) {
-          unschedule(boundary);
-          boundary = null;
-          emitBatch(controller);
-        }
+        // Anything still batched — or carried — belongs ahead of the payload scripts, which sit at the end of
+        // `<body>`. Called unconditionally: a `carry` outlives its boundary, and an empty batch returns early.
+        if (boundary) unschedule(boundary);
+        emitBatch(controller, true);
         // A writable side that closed without ever reaching `transform` — an HTML stream with no chunks at
         // all — leaves nothing to have started the payload, and `flightDone` is only ever called from that
         // chain or from `cancel`. Without this the await below parks on a promise nothing will settle and the

--- a/packages/core/src/runtime/flight-inject.ts
+++ b/packages/core/src/runtime/flight-inject.ts
@@ -73,8 +73,9 @@ function endsWithTrailer(buffer: Uint8Array, length: number): boolean {
  * document that nothing else escapes. The value is not attacker-controlled today, but the framework does not
  * own where it comes from: `c.get('secureHeadersNonce')` is an ordinary context variable that any middleware
  * can set, and a nonce carrying a `"` would close the attribute and open a script-injection point in the
- * document. Anything outside this set is dropped rather than escaped: a value this is not is not a nonce, and
- * a page whose payload scripts are then refused by the policy is the visible failure to have.
+ * document. Anything outside this set is dropped rather than escaped, because a value made of other characters
+ * is not a nonce at all: a page whose payload scripts the policy then refuses is the visible failure to have,
+ * where an escaped garbage nonce would be a silent one.
  */
 const NONCE_CHARS = /^[A-Za-z0-9+/=_-]+$/;
 

--- a/packages/core/src/runtime/flight-inject.ts
+++ b/packages/core/src/runtime/flight-inject.ts
@@ -82,7 +82,7 @@ const NONCE_CHARS = /^[A-Za-z0-9+/=_-]+$/;
 export function injectFlightPayload(
   rscStream: ReadableStream<Uint8Array>,
   options: { nonce?: string; onDone?: () => void } = {},
-): TransformStream<Uint8Array, Uint8Array> {
+): ReadableWritablePair<Uint8Array, Uint8Array> {
   const { nonce, onDone } = options;
   const safeNonce = nonce !== undefined && NONCE_CHARS.test(nonce) ? nonce : undefined;
   const scriptOpen = `<script${safeNonce ? ` nonce="${safeNonce}"` : ''}>(self.__FLIGHT_DATA||=[]).push(`;
@@ -104,6 +104,81 @@ export function injectFlightPayload(
   let cancelled = false;
   /** Held so {@link cancelled} can release the teed RSC branch rather than leaving it to be pumped. */
   let flightReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  /**
+   * One permit per chunk the consumer has asked for: the backpressure a `TransformStream` alone does not give
+   * this module.
+   *
+   * A transform's writable side parks a write while its readable's queue is over the mark, which covers the
+   * HTML — but only once something has been enqueued, and `transform` defers that to a macrotask. So a
+   * producer that writes a whole document without ever yielding the microtask queue is admitted in full, and
+   * {@link writeFlight}, which pumps the payload into the same controller from a detached promise, is never
+   * gated at all: measured, a consumer that read one chunk and stalled still pulled all 500 chunks of a test
+   * payload into the queue, where this brings it down to 3. `controller.desiredSize` is no help — a transform
+   * readable's high-water mark is 0, so it is never positive.
+   *
+   * The wrapper readable this function returns is the missing signal: its `pull` runs exactly when the
+   * consumer wants another chunk, and releases one permit. Both producers — the HTML batcher and the payload
+   * pump — take one before they enqueue, so a stalled client parks React instead of filling the process. The
+   * Streams standard calls `pull` again only once the previous call has settled, so at most one permit is ever
+   * outstanding, which bounds the queue at a chunk.
+   *
+   * What is left buffered is one React flush, because a flush has to leave here as a single chunk (see
+   * {@link emitBatch}) — the same bound React itself holds while it builds one. The two enqueues in `flush`
+   * are ungated for a related reason: the response is over by then, and parking its last two chunks on a
+   * permit would only add a way for it not to end.
+   */
+  let permits = 0;
+  const waiting: Array<() => void> = [];
+
+  /** Returns nothing when a permit was already free, so the common case costs no microtask. */
+  function takePermit(): Promise<void> | undefined {
+    // Nothing will release another permit once the consumer is gone, and there is nothing left to protect:
+    // the caller goes on to a failing enqueue, which is what tears the pipeline down.
+    if (cancelled) return;
+    if (permits > 0) {
+      permits--;
+      return;
+    }
+    return new Promise<void>((resolve) => waiting.push(resolve));
+  }
+
+  function releasePermit(): void {
+    const next = waiting.shift();
+    if (next) next();
+    else permits++;
+  }
+
+  /** Fires `onDone` at most once, however the response ended — both cancel paths can reach it. */
+  let ended = false;
+  function reportDone(): void {
+    if (ended) return;
+    ended = true;
+    onDone?.();
+  }
+
+  /**
+   * The consumer has gone away: stop producing, release everything the request was holding, and unpark both
+   * producers so they see {@link cancelled} rather than a permit that will never come.
+   *
+   * Called from the wrapper readable's `cancel`, which is reliable, and from the transformer's, which the
+   * standard skips once the close algorithm has started — so it has to be idempotent.
+   */
+  function teardown(reason?: unknown): void {
+    cancelled = true;
+    if (boundary) {
+      unschedule(boundary);
+      boundary = null;
+    }
+    batch.length = 0;
+    for (const resolve of waiting.splice(0)) resolve();
+    // Otherwise the teed RSC branch keeps being pumped for a response nobody will read, and the tee's
+    // other half buffers every chunk waiting for this one to catch up.
+    flightReader?.cancel(reason).catch(() => {});
+    // Unparks `flush` if it is waiting on a payload that will now never arrive.
+    flightDone();
+    reportDone();
+  }
 
   /**
    * Emits the HTML buffered since the last boundary, holding back the document trailer for
@@ -139,7 +214,12 @@ export function injectFlightPayload(
     // `fatal`, so a chunk that split a multi-byte character throws instead of emitting U+FFFD; the catch
     // below falls back to a byte-exact encoding for it.
     const decoder = new TextDecoder('utf-8', { fatal: true });
-    const push = (literal: string) => controller.enqueue(encoder.encode(scriptOpen + literal + scriptClose));
+    const push = async (literal: string): Promise<void> => {
+      const permit = takePermit();
+      if (permit) await permit;
+      if (cancelled) return;
+      controller.enqueue(encoder.encode(scriptOpen + literal + scriptClose));
+    };
     for (;;) {
       if (cancelled) return;
       const { done, value } = await reader.read();
@@ -156,7 +236,7 @@ export function injectFlightPayload(
       // A failed enqueue means the consumer is gone: release the RSC branch so `flush` unparks now rather
       // than whenever the payload would have ended on its own.
       try {
-        push(literal);
+        await push(literal);
       } catch {
         cancelled = true;
         reader.cancel().catch(() => {});
@@ -165,21 +245,33 @@ export function injectFlightPayload(
     }
     if (cancelled) return;
     const remaining = decoder.decode();
-    if (remaining.length) push(escapeScript(JSON.stringify(remaining)));
+    if (remaining.length) await push(escapeScript(JSON.stringify(remaining)));
   }
 
   const transformer: CancellableTransformer<Uint8Array, Uint8Array> = {
-    transform(chunk, controller) {
+    async transform(chunk, controller) {
+      if (boundary) {
+        batch.push(chunk);
+        return;
+      }
+      // The permit is taken once per *batch*, not once per chunk: React writes a whole flush in one microtask
+      // cascade and the flush has to leave here as one chunk (see `emitBatch`), so a per-chunk gate would
+      // hand the consumer one chunk per read instead. `transform` is never re-entered concurrently — the
+      // writable side serializes it on the promise this returns — so nothing else can claim the batch in
+      // between.
+      const permit = takePermit();
+      if (permit) await permit;
       batch.push(chunk);
-      if (boundary) return;
       // A macrotask, not a microtask: React writes a whole flush in one synchronous run but `pipeThrough`
       // delivers it one microtask at a time, and a script injected between two chunks lands inside a tag.
       boundary = schedule(() => {
         try {
           emitBatch(controller);
         } catch (error) {
+          // A dead consumer, all but always. `teardown` rather than `flightDone` alone: a payload pump parked
+          // on a permit has to be unparked too, and the RSC branch it holds released.
           controller.error(error);
-          flightDone();
+          teardown(error);
           return;
         }
         if (!startedFlight) {
@@ -213,13 +305,10 @@ export function injectFlightPayload(
               .catch((error) => controller.error(error))
               .then(flightDone);
         }
-      } catch {
+      } catch (error) {
         // The consumer went away while the batch was being emitted, so there is nothing left to write to and
         // nothing to wait for. Settled explicitly rather than left dangling, so the payload chain is released.
-        cancelled = true;
-        flightReader?.cancel().catch(() => {});
-        flightDone();
-        onDone?.();
+        teardown(error);
         return;
       }
 
@@ -235,23 +324,37 @@ export function injectFlightPayload(
         flightReader?.cancel().catch(() => {});
       } finally {
         // A `finally` because `onDone` releases the abort forwarder in `renderComponent`, however this ended.
-        onDone?.();
+        reportDone();
       }
     },
     cancel(reason) {
-      cancelled = true;
-      if (boundary) {
-        unschedule(boundary);
-        boundary = null;
-      }
-      batch.length = 0;
-      // Otherwise the teed RSC branch keeps being pumped for a response nobody will read, and the tee's
-      // other half buffers every chunk waiting for this one to catch up.
-      flightReader?.cancel(reason).catch(() => {});
-      // Unparks `flush` if it is waiting on a payload that will now never arrive.
-      flightDone();
-      onDone?.();
+      teardown(reason);
     },
   };
-  return new TransformStream<Uint8Array, Uint8Array>(transformer);
+
+  const inner = new TransformStream<Uint8Array, Uint8Array>(transformer);
+  const innerReader = inner.readable.getReader();
+  /**
+   * A pull-driven wrapper around the transform's readable, and the only reason this function does not simply
+   * return the transform: `pull` runs once per chunk the consumer takes, which is the demand signal the two
+   * producers park on (see {@link takePermit}). It is also the one cancel notification the standard never
+   * skips, which is what makes {@link teardown} reliable.
+   */
+  const readable = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      releasePermit();
+      const { done, value } = await innerReader.read();
+      try {
+        if (done) controller.close();
+        else controller.enqueue(value);
+      } catch {
+        // Cancelled while this pull was in flight. `teardown` has already run; there is nobody to hand it to.
+      }
+    },
+    cancel(reason) {
+      teardown(reason);
+      return innerReader.cancel(reason);
+    },
+  });
+  return { readable, writable: inner.writable };
 }

--- a/packages/core/src/runtime/request.ts
+++ b/packages/core/src/runtime/request.ts
@@ -1,3 +1,13 @@
+/**
+ * The header that names the server action a client-initiated call wants to run, and so the header that
+ * decides which of the two action branches a POST takes.
+ *
+ * That choice is a security boundary, not just a dispatch detail. It is deliberately *not* a CORS-safelisted
+ * header: a page on another origin cannot send one without a successful preflight, and the framework answers
+ * no preflight, so the `rsc-action` branch is unreachable cross-origin and carries no origin check of its
+ * own. The `form-action` branch is the forgeable one — a form post needs no preflight — and that is the one
+ * `refusesCrossSiteForm` stands in front of. See `SECURITY.md`.
+ */
 const HEADER_ACTION_ID = 'x-rsc-action';
 
 /**

--- a/packages/core/src/runtime/validate-entries.ts
+++ b/packages/core/src/runtime/validate-entries.ts
@@ -1,0 +1,181 @@
+/**
+ * The two modules an app hands the framework — `src/routes.ts` and `src/server.ts` — checked before
+ * anything is built on them.
+ *
+ * Both arrive through a build-time alias that carries no type the compiler can hold on to, so they used to
+ * be cast and the mistake found later, somewhere else: a `routes` array that skipped `defineRoutes` surfaced
+ * as `TypeError: nN is not iterable` from a minified bundle, and a `src/server.ts` exporting the wrong thing
+ * as `Cannot read properties of undefined (reading 'map')` from inside Hono. Neither names the file to open.
+ * The mistakes that produced no error at all were worse: a duplicated `path` whose second entry silently
+ * never ran, a `staticPaths` on a route that renders per request.
+ *
+ * Everything here runs once, at module load — during `rshono build`, which imports the server bundle for the
+ * prerender pass; at `rshono dev` startup; and when a deployed server boots.
+ */
+
+import type { Hono } from 'hono';
+import { isPageRoute, type Route, type RouteConfig } from '../router.js';
+
+/** Every method an endpoint route can name, `'all'` aside — which is also what `'all'` is expanded to below. */
+const CONCRETE_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options'];
+const METHODS = new Set([...CONCRETE_METHODS, 'all']);
+
+/** What a page route's `render` accepts. */
+const RENDER_MODES = ['static', 'dynamic'];
+
+function fail(message: string): never {
+  throw new Error(`[rshono] ${message}`);
+}
+
+/**
+ * How a route is named in a message. Always by position, because that is what a duplicate `path` needs to be
+ * told apart, and by path as well wherever there is one.
+ */
+function label(route: unknown, index: number): string {
+  const path = (route as { path?: unknown } | null)?.path;
+  return typeof path === 'string' ? `routes[${index}] ("${path}")` : `routes[${index}]`;
+}
+
+/** Refuses a key that belongs to the *other* kind of route — see {@link validateRoute}. */
+function refuseForeignKeys(route: Record<string, unknown>, name: string, keys: readonly string[], advice: string): void {
+  for (const key of keys) {
+    if (route[key] !== undefined) fail(`src/routes.ts: ${name} has \`${key}\`, which ${advice}`);
+  }
+}
+
+/**
+ * Checks one entry of the route table.
+ *
+ * The cross-kind key checks are the ones TypeScript cannot make: excess-property checking against a union
+ * accepts any key present in *some* member, so `staticPaths` on an `{ type: 'endpoint' }` route type-checks
+ * and is then ignored at runtime — which is indistinguishable from prerendering that quietly does nothing.
+ */
+function validateRoute(route: unknown, index: number): void {
+  if (route === null || typeof route !== 'object') {
+    fail(`src/routes.ts: routes[${index}] is ${route === null ? 'null' : typeof route}, not a route object.`);
+  }
+  const entry = route as Record<string, unknown>;
+  const name = label(route, index);
+
+  if (typeof entry.path !== 'string' || !entry.path.startsWith('/')) {
+    fail(`src/routes.ts: ${name} needs a \`path\` starting with "/".`);
+  }
+  if (entry.type !== undefined && entry.type !== 'endpoint') {
+    fail(`src/routes.ts: ${name} has type ${JSON.stringify(entry.type)} — the only \`type\` is 'endpoint', and a page route omits it.`);
+  }
+
+  if (entry.type === 'endpoint') {
+    if (typeof entry.server !== 'function') {
+      fail(`src/routes.ts: ${name} is an endpoint, so it needs \`server\` — a function importing the module that exports \`handler\`.`);
+    }
+    if (entry.method !== undefined && (typeof entry.method !== 'string' || !METHODS.has(entry.method))) {
+      const meantHead = typeof entry.method === 'string' && entry.method.toLowerCase() === 'head';
+      fail(
+        `src/routes.ts: ${name} has method ${JSON.stringify(entry.method)}, which is not one of ${[...METHODS].join(', ')}.` +
+          (meantHead ? " A HEAD is dispatched as a GET, so use 'get' — a route registered for HEAD alone answers neither." : ''),
+      );
+    }
+    refuseForeignKeys(
+      entry,
+      name,
+      ['component', 'render', 'staticPaths'],
+      "only a page route has — an endpoint's `server` handler decides its own response.",
+    );
+  } else {
+    if (typeof entry.component !== 'function') {
+      fail(`src/routes.ts: ${name} needs \`component\` — a function importing the page module, e.g. \`() => import('./pages/home')\`.`);
+    }
+    if (entry.render !== undefined && (typeof entry.render !== 'string' || !RENDER_MODES.includes(entry.render))) {
+      fail(`src/routes.ts: ${name} has render ${JSON.stringify(entry.render)} — it is 'static' or 'dynamic'.`);
+    }
+    if (entry.staticPaths !== undefined) {
+      if (typeof entry.staticPaths !== 'function') fail(`src/routes.ts: ${name} has a \`staticPaths\` that is not a function.`);
+      if (entry.render !== 'static') {
+        fail(`src/routes.ts: ${name} has \`staticPaths\` but is not \`render: 'static'\`, so it renders per request and the paths are never built.`);
+      }
+    }
+    refuseForeignKeys(entry, name, ['server', 'method'], "only an endpoint route has — add `type: 'endpoint'` if that is what this is.");
+  }
+}
+
+/** The methods a route answers, with `'all'` expanded, so two registrations can be compared. */
+function methodsOf(route: Route): readonly string[] {
+  // A page is registered for GET and POST: the POST is how a `<form action={serverAction}>` reaches it.
+  if (isPageRoute(route)) return ['get', 'post'];
+  const method = route.method ?? 'all';
+  return method === 'all' ? CONCRETE_METHODS : [method];
+}
+
+/**
+ * Refuses a route the table already answers in full. Hono matches in registration order, so a later entry
+ * whose every method and path is spoken for is dead code — and the build that produced it exits 0 with
+ * nothing to say, which is how a duplicated `path` survives.
+ *
+ * Method by method, and only when *all* of them are taken: one path split between a `'get'` endpoint and a
+ * `'post'` one shadows nothing, and neither does a catch-all registered behind a route that claims one
+ * method of it — that one still answers the rest.
+ */
+function assertNothingIsShadowed(routes: readonly Route[]): void {
+  /** `"<method> <path>"` → the first route answering it. */
+  const claimed = new Map<string, string>();
+  routes.forEach((route, index) => {
+    const name = label(route, index);
+    const methods = methodsOf(route);
+    const claimants = methods.map((method) => claimed.get(`${method} ${route.path}`));
+    if (claimants.every((claimant) => claimant !== undefined)) {
+      const by = [...new Set(claimants)].join(' and ');
+      const verbs = methods.map((method) => method.toUpperCase()).join(', ');
+      fail(`src/routes.ts: ${name} would never run — ${by} already answers ${verbs} ${route.path}, and Hono matches in registration order.`);
+    }
+    for (const method of methods) {
+      const key = `${method} ${route.path}`;
+      if (!claimed.has(key)) claimed.set(key, name);
+    }
+  });
+}
+
+function validateFallbackPage(page: unknown, field: 'notFound' | 'error'): void {
+  if (page === undefined || page === null) return;
+  if (typeof page !== 'object' || typeof (page as { component?: unknown }).component !== 'function') {
+    fail(`src/routes.ts: \`${field}\` must be a page — \`{ component: () => import('./pages/${field}') }\`.`);
+  }
+}
+
+/**
+ * Normalises and checks what `src/routes.ts` exported as `routes`.
+ *
+ * A bare array is accepted alongside a {@link RouteConfig}, because the docs present both and
+ * `defineRoutes` is an identity function over the array form — which makes leaving it off look equivalent
+ * right up to the point the build fails somewhere unrelated.
+ */
+export function validateRoutesModule(exported: unknown): RouteConfig {
+  const config = (Array.isArray(exported) ? { routes: exported as Route[] } : exported) as RouteConfig | null | undefined;
+  if (config === null || config === undefined || typeof config !== 'object' || !Array.isArray(config.routes)) {
+    fail(
+      'src/routes.ts must export `routes` as a route array, or as a { routes, notFound?, error? } object — ' +
+        'wrap it in `defineRoutes(…)` to have TypeScript check it for you.',
+    );
+  }
+
+  config.routes.forEach(validateRoute);
+  assertNothingIsShadowed(config.routes);
+  validateFallbackPage(config.notFound, 'notFound');
+  validateFallbackPage(config.error, 'error');
+  return config;
+}
+
+/**
+ * The Hono app `src/server.ts` default-exports, or `null` for an app that has no `src/server.ts` — the
+ * fallback module the alias resolves to instead default-exports exactly that.
+ *
+ * Duck-typed rather than `instanceof Hono`: what the framework does with the value is `app.route('/', …)`,
+ * which reads `routes` off it and mounts the handlers, so those are what have to be there.
+ */
+export function validateServerApp(exported: unknown): Hono | null {
+  const app = (exported as { default?: unknown } | null)?.default;
+  if (app === null || app === undefined) return null;
+  if (typeof app !== 'object' || typeof (app as Hono).fetch !== 'function' || !Array.isArray((app as Hono).routes)) {
+    fail('src/server.ts must `export default` a Hono app — `const server = new Hono(); … export default server;`.');
+  }
+  return app as Hono;
+}

--- a/packages/core/src/runtime/validate-entries.ts
+++ b/packages/core/src/runtime/validate-entries.ts
@@ -68,13 +68,7 @@ function validateRoute(route: unknown, index: number): void {
     if (typeof entry.server !== 'function') {
       fail(`src/routes.ts: ${name} is an endpoint, so it needs \`server\` — a function importing the module that exports \`handler\`.`);
     }
-    if (entry.method !== undefined && (typeof entry.method !== 'string' || !METHODS.has(entry.method))) {
-      const meantHead = typeof entry.method === 'string' && entry.method.toLowerCase() === 'head';
-      fail(
-        `src/routes.ts: ${name} has method ${JSON.stringify(entry.method)}, which is not one of ${[...METHODS].join(', ')}.` +
-          (meantHead ? " A HEAD is dispatched as a GET, so use 'get' — a route registered for HEAD alone answers neither." : ''),
-      );
-    }
+    if (entry.method !== undefined) validateMethod(entry.method, name);
     refuseForeignKeys(
       entry,
       name,
@@ -98,12 +92,38 @@ function validateRoute(route: unknown, index: number): void {
   }
 }
 
-/** The methods a route answers, with `'all'` expanded, so two registrations can be compared. */
+/**
+ * Checks an endpoint's `method`, which is one method or a list of them.
+ *
+ * A list is checked member by member so the message names the bad one rather than printing the array, and
+ * `'all'` is refused inside one: a list meaning every method is a list its author did not mean to write.
+ */
+function validateMethod(method: unknown, name: string): void {
+  if (Array.isArray(method)) {
+    if (method.length === 0) fail(`src/routes.ts: ${name} has an empty \`method\` list — omit it to answer every method.`);
+    for (const entry of method as unknown[]) {
+      if (entry === 'all') {
+        fail(`src/routes.ts: ${name} has 'all' inside a \`method\` list — use \`method: 'all'\`, or list the methods it answers.`);
+      }
+      validateMethod(entry, name);
+    }
+    return;
+  }
+  if (typeof method !== 'string' || !METHODS.has(method)) {
+    const meantHead = typeof method === 'string' && method.toLowerCase() === 'head';
+    fail(
+      `src/routes.ts: ${name} has method ${JSON.stringify(method)}, which is not one of ${[...METHODS].join(', ')}.` +
+        (meantHead ? " A HEAD is dispatched as a GET, so use 'get' — a route registered for HEAD alone answers neither." : ''),
+    );
+  }
+}
+
+/** The methods a route answers, with `'all'` expanded and a list flattened, so two can be compared. */
 function methodsOf(route: Route): readonly string[] {
   // A page is registered for GET and POST: the POST is how a `<form action={serverAction}>` reaches it.
   if (isPageRoute(route)) return ['get', 'post'];
-  const method = route.method ?? 'all';
-  return method === 'all' ? CONCRETE_METHODS : [method];
+  const methods = [route.method ?? 'all'].flat();
+  return methods.includes('all') ? CONCRETE_METHODS : methods;
 }
 
 /**

--- a/packages/core/src/server/prerendered.ts
+++ b/packages/core/src/server/prerendered.ts
@@ -22,6 +22,18 @@ export const VARIANTS = {
 } as const satisfies Record<PrerenderVariant, { file: string; headers: Record<string, string>; contentType: string }>;
 
 /**
+ * The index the build leaves beside the pages, naming every file it wrote — one `files` array of
+ * {@link ssgFilePath} names.
+ *
+ * It exists so a reader can tell "this store has no page for that path" without asking the store, which is
+ * the difference between a `Map` lookup and a failed `readFile` (or, without a filesystem, a failed store
+ * fetch) on **every** request to a static route the build could not prerender — misses are deliberately not
+ * cached, so that one never warms up. Absent is not an error: a build from an older rshono has none, and a
+ * reader that finds none looks the way it always did.
+ */
+export const SSG_MANIFEST_FILE = 'manifest.json';
+
+/**
  * What a decoded path segment may not hold if it is to be one portable file name. `\ / : * ? " < > |` are
  * refused by Windows and `/` by every host, so a `staticPaths` value containing one fails the build rather
  * than writing a page on one machine and not on another — and a route pattern, whose params and wildcards are

--- a/packages/core/src/server/prerendered.ts
+++ b/packages/core/src/server/prerendered.ts
@@ -22,26 +22,75 @@ export const VARIANTS = {
 } as const satisfies Record<PrerenderVariant, { file: string; headers: Record<string, string>; contentType: string }>;
 
 /**
- * Where a route's prerendered output lives, relative to the output root — or `null` for a path that cannot be
- * prerendered at all, one with a param or a wildcard left in it.
- *
- * Always `/`-separated: the same string addresses a file on a filesystem, which accepts forward slashes on
- * Windows too, and a key in an asset store, where a backslash would be the wrong character.
+ * What a decoded path segment may not hold if it is to be one portable file name. `\ / : * ? " < > |` are
+ * refused by Windows and `/` by every host, so a `staticPaths` value containing one fails the build rather
+ * than writing a page on one machine and not on another — and a route pattern, whose params and wildcards are
+ * spelled with `:` and `*`, falls out of the same rule.
  */
-export function ssgFilePath(routePath: string, variant: PrerenderVariant = 'html'): string | null {
-  if (/[:*]/.test(routePath)) return null;
-  const trimmed = routePath.replace(/^\/+|\/+$/g, '');
-  const file = VARIANTS[variant].file;
-  return trimmed === '' ? file : `${trimmed}/${file}`;
+const UNPORTABLE_SEGMENT = /[\\/:*?"<>|]/;
+
+/**
+ * Decodes one path segment the way a URL does, treating a malformed escape as the literal text it is:
+ * `decodeURIComponent('%')` throws, and a request path is whatever the client chose to send.
+ */
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
 }
 
 /**
- * {@link ssgFilePath} for a path that came off a request, so traversal is a miss rather than a lookup. A store
- * addressed by key has no `resolve()` to fall back on, so `..` is refused here or not at all.
+ * Whether one decoded segment can be a directory in the prerender tree: not empty, not a relative-path
+ * marker, and made only of characters a file name can hold — {@link UNPORTABLE_SEGMENT}, plus the control
+ * characters, which a percent-escape is free to carry into a path and no filesystem wants in a name.
  */
-export function prerenderedRelPath(requestPath: string, variant: PrerenderVariant): string | null {
-  if (/(^|\/)\.\.?(\/|$)/.test(requestPath)) return null;
-  return ssgFilePath(requestPath, variant);
+function isStorableSegment(segment: string): boolean {
+  if (segment === '' || segment === '.' || segment === '..') return false;
+  return !UNPORTABLE_SEGMENT.test(segment) && ![...segment].some((char) => char < ' ');
+}
+
+/**
+ * Where a path's prerendered output lives, relative to the output root — or `null` for a path no single file
+ * can answer.
+ *
+ * **The one canonical form**, shared by the build that writes the file and by every deploy target that reads
+ * it back, because the two drifting apart is invisible: the build reports the page as prerendered and every
+ * request afterwards falls through to SSR, forever. Each segment is stored *decoded*, so `/docs/café` is
+ * `docs/café` whether the caller holds the path percent-encoded — the build, which interpolates `staticPaths`
+ * values into a URL — or already decoded, as Hono's `c.req.path` is: it runs `decodeURI` over any path
+ * containing a `%`. Decoded is also the form every other static file server addresses, so the tree stays
+ * servable by something that is not this framework.
+ *
+ * Always `/`-separated: the same string addresses a file on a filesystem, which accepts forward slashes on
+ * Windows too, and a key in an asset store, where a backslash would be the wrong character.
+ *
+ * `null` is everything that is not one file: a `.` or `..` segment — so traversal is a miss rather than a
+ * lookup, which a store addressed by key, with no `resolve()` to fall back on, depends on — an empty segment,
+ * and any segment holding a character a file name cannot.
+ */
+export function ssgFilePath(path: string, variant: PrerenderVariant = 'html'): string | null {
+  const file = VARIANTS[variant].file;
+  const trimmed = path.replace(/^\/+|\/+$/g, '');
+  if (trimmed === '') return file;
+
+  const segments: string[] = [];
+  for (const encoded of trimmed.split('/')) {
+    const segment = decodeSegment(encoded);
+    if (!isStorableSegment(segment)) return null;
+    segments.push(segment);
+  }
+  return `${segments.join('/')}/${file}`;
+}
+
+/**
+ * {@link ssgFilePath} as a URL path, for a store addressed by one rather than by key. Every segment is escaped
+ * on the way out and the store decodes it back, so a page reached through a URL lands on the same file a
+ * filesystem target opens by name.
+ */
+export function ssgAssetPath(relPath: string): string {
+  return relPath.split('/').map(encodeURIComponent).join('/');
 }
 
 /** The default cache budget: enough for a large documentation site's working set, small enough to be ignorable. */

--- a/packages/core/src/server/server-config.ts
+++ b/packages/core/src/server/server-config.ts
@@ -30,6 +30,32 @@ export const SERVER_DEFAULTS = {
   host: '0.0.0.0',
 } as const;
 
+/** The highest port a TCP listener can bind. `0` is the lowest, and means "any free port". */
+const MAX_PORT = 65535;
+
+/**
+ * Reads a port out of `--port` or `PORT`, so both are read the same way wherever the address is resolved.
+ *
+ * A blank value is `undefined` — "unset", falling through to {@link SERVER_DEFAULTS}. An empty `PORT` is
+ * common in CI images and container templates, and the other reading of it is a silent failure: `Number('')`
+ * is `0`, which binds a random free port and then reports success.
+ *
+ * @param source how to name the value in the error — the flag or the variable it came from.
+ * @throws RangeError for anything present that is not a port, rather than letting `NaN` reach Node as a raw
+ *   `ERR_SOCKET_BAD_PORT` with a bundler frame in the stack.
+ */
+export function parsePort(value: string | undefined, source: string): number | undefined {
+  const text = value?.trim();
+  if (!text) return undefined;
+  // Digits only: `Number` alone would also accept `0x50`, `1e3`, `+80` and `3.0`, none of which anyone
+  // typed meaning the port they would get.
+  const port = /^\d+$/.test(text) ? Number(text) : Number.NaN;
+  if (Number.isNaN(port) || port > MAX_PORT) {
+    throw new RangeError(`invalid ${source} ${JSON.stringify(value)} — expected an integer between 0 and ${MAX_PORT}.`);
+  }
+  return port;
+}
+
 /**
  * Resolves the user's config into the {@link ServerConfig} baked into the bundle. `isDev` is a build-time input
  * rather than a config field because it decides one thing the user should not have to: `trustProxy` is forced on

--- a/packages/core/src/server/ssg.ts
+++ b/packages/core/src/server/ssg.ts
@@ -2,7 +2,15 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
 import { isPageRoute, type PageRoute, type Route } from '../router.js';
-import { createPageCache, ssgFilePath, toPrerenderedPage, VARIANTS, type PrerenderedPage, type PrerenderVariant } from './prerendered.js';
+import {
+  createPageCache,
+  ssgFilePath,
+  SSG_MANIFEST_FILE,
+  toPrerenderedPage,
+  VARIANTS,
+  type PrerenderedPage,
+  type PrerenderVariant,
+} from './prerendered.js';
 
 /**
  * Stand-in origin for a build that declared no `siteUrl`. Obviously wrong rather than a guess, so a page that
@@ -52,6 +60,25 @@ function interpolatePath(pattern: string, params: Record<string, string>): strin
 /** Prerendered pages, keyed by the request that produced them (see {@link readPrerendered}). */
 const pageCache = createPageCache();
 
+/** One in-flight or settled read of each store's {@link SSG_MANIFEST_FILE}; the file cannot change while the server is up. */
+const storeIndexes = new Map<string, Promise<ReadonlySet<string> | null>>();
+
+/**
+ * What `ssgDir` holds, as {@link ssgFilePath} names it — or `null` where the build left no manifest, which
+ * is every build made before there was one. A `null` gates nothing, so those keep the behaviour they had.
+ */
+function storeIndex(ssgDir: string): Promise<ReadonlySet<string> | null> {
+  let pending = storeIndexes.get(ssgDir);
+  if (!pending) {
+    // One `catch` for both failures worth the same answer: no manifest, and a manifest that is not one.
+    pending = readFile(join(ssgDir, SSG_MANIFEST_FILE), 'utf8')
+      .then((text) => new Set((JSON.parse(text) as { files?: string[] }).files ?? []) as ReadonlySet<string>)
+      .catch(() => null);
+    storeIndexes.set(ssgDir, pending);
+  }
+  return pending;
+}
+
 export async function readPrerendered(ssgDir: string, requestPath: string, variant: PrerenderVariant = 'html'): Promise<PrerenderedPage | null> {
   // Keyed by what the request carried rather than by the resolved filename, so a hit costs one Map lookup. Safe
   // because only *hits* are cached: an entry exists only if this exact key already passed the checks below.
@@ -61,6 +88,12 @@ export async function readPrerendered(ssgDir: string, requestPath: string, varia
 
   const relPath = ssgFilePath(requestPath, variant);
   if (relPath === null) return null;
+
+  // Before the store is touched: a `render: 'static'` route whose build wrote nothing — no `staticPaths`, a
+  // param the build never saw, a page that did not render cleanly — falls through to SSR on every request,
+  // and without this each of those pays a failed read first, forever.
+  const index = await storeIndex(ssgDir);
+  if (index && !index.has(relPath)) return null;
   // Belt and braces over the shared traversal guard: this proves the resolved file is under the root.
   const root = resolve(ssgDir);
   const file = resolve(root, relPath);
@@ -94,6 +127,16 @@ export interface PrerenderResult {
 }
 
 /**
+ * Records what the pass wrote, beside what it wrote. Written by the same pass for the same reason
+ * {@link ssgFilePath} is one function: an index that disagrees with the store is invisible, so the two are
+ * produced together or not at all.
+ */
+function writeManifest(ssgDir: string, files: readonly string[]): void {
+  mkdirSync(ssgDir, { recursive: true });
+  writeFileSync(join(ssgDir, SSG_MANIFEST_FILE), `${JSON.stringify({ files }, null, 2)}\n`);
+}
+
+/**
  * One representation of a path, as the app answered for it at build time. Discriminated on `ok` because both
  * callers have to tell "the app rendered this" from "it did not", and only one cares why.
  */
@@ -122,6 +165,8 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
 
   const written: string[] = [];
   const skipped: string[] = [];
+  /** Every file written, as the reader names it — {@link writeManifest}. */
+  const files: string[] = [];
 
   for (const route of staticRoutes) {
     let paths: string[];
@@ -161,6 +206,9 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
       const write = (variant: PrerenderVariant, body: string) => {
         mkdirSync(pageDir, { recursive: true });
         writeFileSync(join(pageDir, VARIANTS[variant].file), body);
+        // `ssgFilePath` again rather than the `join` above: the manifest is read against what a *request*
+        // resolves to, which is that function's output and not a filesystem path.
+        files.push(ssgFilePath(path, variant)!);
       };
       write('html', document.body);
 
@@ -176,6 +224,10 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
       written.push(path);
     }
   }
+
+  // Only where the app has static routes at all: an empty manifest would be a store, and a build with
+  // nothing to prerender should leave no `ssg/` directory for a preset to carry around.
+  if (staticRoutes.length > 0) writeManifest(ssgDir, files);
 
   return { written, skipped };
 }

--- a/packages/core/src/server/ssg.ts
+++ b/packages/core/src/server/ssg.ts
@@ -144,6 +144,32 @@ function writeManifest(ssgDir: string, files: readonly string[]): void {
 }
 
 /**
+ * How many paths are rendered at once.
+ *
+ * A prerender pass spends its time inside the app — a page's own data fetching is what each render awaits —
+ * so a few hundred `staticPaths` entries rendered one at a time pay all of that latency in series.
+ * Unbounded is the other wrong answer: it points the whole site at the app's database in one go. Eight keeps
+ * a build's peak load recognisable while hiding most of the wait.
+ */
+const RENDER_CONCURRENCY = 8;
+
+/**
+ * `items.map(run)` with at most `limit` running at once, results in input order.
+ *
+ * A worker pool rather than fixed batches: a batch is only as fast as its slowest member, so one slow page
+ * would idle the rest of its batch.
+ */
+async function mapBounded<T, R>(items: readonly T[], limit: number, run: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    for (let index = next++; index < items.length; index = next++) results[index] = await run(items[index]);
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+/**
  * One representation of a path, as the app answered for it at build time. Discriminated on `ok` because both
  * callers have to tell "the app rendered this" from "it did not", and only one cares why.
  */
@@ -156,6 +182,13 @@ async function renderVariant(fetch: PrerenderOptions['fetch'], url: string, vari
     return { ok: false, reason: `a non-${VARIANTS[variant].contentType} response` };
   }
   return { ok: true, body: await response.text() };
+}
+
+/** A path the pass will render, resolved far enough that nothing left can fail the build. */
+interface PrerenderTarget {
+  path: string;
+  /** Where a request for it will look — {@link ssgFilePath}, resolved before the render rather than after. */
+  relPath: string;
 }
 
 export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<PrerenderResult> {
@@ -174,6 +207,11 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
   const skipped: string[] = [];
   /** Every file written, as the reader names it — {@link writeManifest}. */
   const files: string[] = [];
+
+  /** Every path to render, in route order, each one once. Built before anything renders — see below. */
+  const targets: PrerenderTarget[] = [];
+  /** So a `staticPaths` entry that repeats — or that a second route also produces — is rendered once. */
+  const queued = new Set<string>();
 
   for (const route of staticRoutes) {
     let paths: string[];
@@ -199,11 +237,18 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
       }
     }
 
+    let duplicates = 0;
     for (const path of paths) {
+      if (queued.has(path)) {
+        duplicates++;
+        continue;
+      }
+      queued.add(path);
       // Resolved *before* the render, so a path no file can hold fails the build naming the path, rather than
       // after the work and as a bare `join(dir, null)` TypeError. The same call answers for the reader, which
       // is the whole point: a page written under a name the request path never resolves to is a page the build
-      // reports as prerendered and nothing ever serves.
+      // reports as prerendered and nothing ever serves. Resolved in this pass rather than the next one for a
+      // second reason too: which of several bad paths fails the build should not depend on render order.
       const relPath = ssgFilePath(path, 'html');
       if (relPath === null) {
         throw new Error(
@@ -211,36 +256,56 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
             `character a portable file name cannot — one of \\ / : * ? " < > | or a control character.`,
         );
       }
-      const pageDir = join(ssgDir, dirname(relPath));
-
-      const document = await renderVariant(fetch, origin + path, 'html');
-      if (!document.ok) {
-        console.warn(`  ⚠ "${path}" rendered ${document.reason} at build time — skipping, will SSR per request.`);
-        skipped.push(path);
-        continue;
-      }
-
-      // Both representations of a page share its directory and differ only in the file name.
-      const write = (variant: PrerenderVariant, body: string) => {
-        mkdirSync(pageDir, { recursive: true });
-        writeFileSync(join(pageDir, VARIANTS[variant].file), body);
-        // `ssgFilePath` again rather than the `join` above: the manifest is read against what a *request*
-        // resolves to, which is that function's output and not a filesystem path.
-        files.push(ssgFilePath(path, variant)!);
-      };
-      write('html', document.body);
-
-      // The soft-navigation representation of the same page. Best-effort: the document is valid on its own, and
-      // serving falls back to rendering the flight payload per request.
-      const flight = await renderVariant(fetch, origin + path, 'flight');
-      if (flight.ok) {
-        write('flight', flight.body);
-      } else {
-        console.warn(`  ⚠ "${path}" produced no flight payload — soft navigations to it will render per request.`);
-      }
-
-      written.push(path);
+      targets.push({ path, relPath });
     }
+    if (duplicates > 0) {
+      console.warn(`  ⚠ Static route "${route.path}" repeated ${duplicates} path${duplicates === 1 ? '' : 's'} — each page is prerendered once.`);
+    }
+  }
+
+  const outcomes = await mapBounded(targets, RENDER_CONCURRENCY, async ({ path, relPath }) => {
+    /** Buffered, so a concurrent pass logs in the same order a serial one did. */
+    const warnings: string[] = [];
+    const document = await renderVariant(fetch, origin + path, 'html');
+    if (!document.ok) {
+      warnings.push(`  ⚠ "${path}" rendered ${document.reason} at build time — skipping, will SSR per request.`);
+      return { path, ok: false as const, files: [], warnings };
+    }
+
+    // Both representations of a page share its directory and differ only in the file name.
+    const pageDir = join(ssgDir, dirname(relPath));
+    const wrote: string[] = [];
+    const write = (variant: PrerenderVariant, body: string) => {
+      mkdirSync(pageDir, { recursive: true });
+      writeFileSync(join(pageDir, VARIANTS[variant].file), body);
+      // `ssgFilePath` again rather than the `join` above: the manifest is read against what a *request*
+      // resolves to, which is that function's output and not a filesystem path.
+      wrote.push(ssgFilePath(path, variant)!);
+    };
+    write('html', document.body);
+
+    // The soft-navigation representation of the same page. Best-effort: the document is valid on its own, and
+    // serving falls back to rendering the flight payload per request.
+    const flight = await renderVariant(fetch, origin + path, 'flight');
+    if (flight.ok) {
+      write('flight', flight.body);
+    } else {
+      warnings.push(`  ⚠ "${path}" produced no flight payload — soft navigations to it will render per request.`);
+    }
+
+    return { path, ok: true as const, files: wrote, warnings };
+  });
+
+  // Folded back in target order rather than completion order, so a concurrent pass writes the same manifest
+  // and prints the same log a serial one did.
+  for (const outcome of outcomes) {
+    for (const warning of outcome.warnings) console.warn(warning);
+    if (!outcome.ok) {
+      skipped.push(outcome.path);
+      continue;
+    }
+    files.push(...outcome.files);
+    written.push(outcome.path);
   }
 
   // Only where the app has static routes at all: an empty manifest would be a store, and a build with

--- a/packages/core/src/server/ssg.ts
+++ b/packages/core/src/server/ssg.ts
@@ -2,15 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve, sep } from 'node:path';
 import { isPageRoute, type PageRoute, type Route } from '../router.js';
-import {
-  createPageCache,
-  prerenderedRelPath,
-  ssgFilePath,
-  toPrerenderedPage,
-  VARIANTS,
-  type PrerenderedPage,
-  type PrerenderVariant,
-} from './prerendered.js';
+import { createPageCache, ssgFilePath, toPrerenderedPage, VARIANTS, type PrerenderedPage, type PrerenderVariant } from './prerendered.js';
 
 /**
  * Stand-in origin for a build that declared no `siteUrl`. Obviously wrong rather than a guess, so a page that
@@ -67,7 +59,7 @@ export async function readPrerendered(ssgDir: string, requestPath: string, varia
   const cached = pageCache.get(key);
   if (cached) return cached;
 
-  const relPath = prerenderedRelPath(requestPath, variant);
+  const relPath = ssgFilePath(requestPath, variant);
   if (relPath === null) return null;
   // Belt and braces over the shared traversal guard: this proves the resolved file is under the root.
   const root = resolve(ssgDir);
@@ -145,6 +137,19 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
     }
 
     for (const path of paths) {
+      // Resolved *before* the render, so a path no file can hold fails the build naming the path, rather than
+      // after the work and as a bare `join(dir, null)` TypeError. The same call answers for the reader, which
+      // is the whole point: a page written under a name the request path never resolves to is a page the build
+      // reports as prerendered and nothing ever serves.
+      const relPath = ssgFilePath(path, 'html');
+      if (relPath === null) {
+        throw new Error(
+          `Cannot prerender "${path}" for route "${route.path}": a path segment is "." or "..", or holds a ` +
+            `character a portable file name cannot — one of \\ / : * ? " < > | or a control character.`,
+        );
+      }
+      const pageDir = join(ssgDir, dirname(relPath));
+
       const document = await renderVariant(fetch, origin + path, 'html');
       if (!document.ok) {
         console.warn(`  ⚠ "${path}" rendered ${document.reason} at build time — skipping, will SSR per request.`);
@@ -152,10 +157,10 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
         continue;
       }
 
+      // Both representations of a page share its directory and differ only in the file name.
       const write = (variant: PrerenderVariant, body: string) => {
-        const file = join(ssgDir, ssgFilePath(path, variant)!);
-        mkdirSync(dirname(file), { recursive: true });
-        writeFileSync(file, body);
+        mkdirSync(pageDir, { recursive: true });
+        writeFileSync(join(pageDir, VARIANTS[variant].file), body);
       };
       write('html', document.body);
 

--- a/packages/core/src/server/ssg.ts
+++ b/packages/core/src/server/ssg.ts
@@ -34,23 +34,30 @@ export function resolveSiteOrigin(siteUrl: string | undefined): string {
   return parsed.origin;
 }
 
+/**
+ * A route's path with its params filled in, ready to render and to store.
+ *
+ * Throws for a pattern `staticPaths` cannot fill and for a set that does not fill it. Both are warned about
+ * and skipped by the caller, which already names the route — so these messages are the reason alone, written
+ * to be read at the end of that line.
+ */
 function interpolatePath(pattern: string, params: Record<string, string>): string {
   return pattern
     .split('/')
     .map((segment) => {
       if (!segment.startsWith(':')) {
         if (segment.includes('*')) {
-          throw new Error(`Cannot prerender "${pattern}": wildcard segments are not supported by staticPaths.`);
+          throw new Error(`wildcard segments are not supported by staticPaths`);
         }
         return segment;
       }
       const name = segment.slice(1);
       if (!/^\w+$/.test(name)) {
-        throw new Error(`Cannot prerender "${pattern}": optional/regex params are not supported by staticPaths.`);
+        throw new Error(`optional/regex params are not supported by staticPaths`);
       }
       const value = params[name];
       if (value === undefined) {
-        throw new Error(`staticPaths for "${pattern}" returned a param set without "${name}".`);
+        throw new Error(`staticPaths returned a param set without "${name}"`);
       }
       return encodeURIComponent(value);
     })
@@ -178,7 +185,18 @@ export async function prerenderStaticRoutes(options: PrerenderOptions): Promise<
         skipped.push(route.path);
         continue;
       }
-      paths = (await route.staticPaths()).map((params) => interpolatePath(route.path, params));
+      try {
+        paths = (await route.staticPaths()).map((params) => interpolatePath(route.path, params));
+      } catch (error) {
+        // A route whose paths cannot be computed — a wildcard or a regex/optional param, which `staticPaths`
+        // has no way to fill, or a set it filled wrongly — is unprerenderable, not unservable. It gets the
+        // same answer as the branch above rather than killing a build the route would have survived: the
+        // page is still there, rendered per request.
+        const reason = error instanceof Error ? error.message : String(error);
+        console.warn(`  ⚠ Static route "${route.path}" will SSR per request — ${reason.replace(/\.$/, '')}.`);
+        skipped.push(route.path);
+        continue;
+      }
     }
 
     for (const path of paths) {

--- a/packages/core/src/server/static.ts
+++ b/packages/core/src/server/static.ts
@@ -27,7 +27,9 @@ export function createStaticAssetsApp(options: StaticOptions): Hono {
   const { root, isDev } = options;
   const app = new Hono();
 
-  app.on(['GET', 'HEAD'], '/*', cacheControl(isDev), serveStatic({ root, rewriteRequestPath: (path) => path.replace(/^\/_static/, '') }), (c) =>
+  // `GET` alone: Hono dispatches a `HEAD` as a `GET` and strips the body, so a `HEAD` registration beside it
+  // is never reached — see `HTTPMethod`.
+  app.get('/*', cacheControl(isDev), serveStatic({ root, rewriteRequestPath: (path) => path.replace(/^\/_static/, '') }), (c) =>
     c.text('Not Found', 404),
   );
 

--- a/packages/core/src/types/react-server-dom-rspack.d.ts
+++ b/packages/core/src/types/react-server-dom-rspack.d.ts
@@ -1,5 +1,5 @@
 // Hand-written declarations for `react-server-dom-rspack` and the manifest global its Rspack plugins inject.
-// Narrowed to what the framework calls: the package is still `0.0.x`, so anything declared here that nothing
+// Narrowed to what the framework calls: the package is pre-1.0, so anything declared here that nothing
 // uses would be an unverified guess about an API that moves underneath us.
 
 declare const __rspack_rsc_manifest__: {

--- a/packages/core/test/browser/client-runtime.spec.mjs
+++ b/packages/core/test/browser/client-runtime.spec.mjs
@@ -194,6 +194,29 @@ test.describe('server actions', () => {
     await expect(page.getByText(email)).toBeVisible();
   });
 
+  test('an action answered with something that is not a payload reports the status, not a parser error', async ({ page }) => {
+    await page.goto('/users');
+
+    // Stands in for every response the action path can get that is not a flight payload: a `bodyLimit()`
+    // 413, a proxy's error page, a 502 mid-deploy. Handed to the flight parser they all surface as
+    // "Connection closed.", with the status nowhere in sight.
+    await page.route('**/users', async (route, request) => {
+      if (request.method() !== 'POST') return route.continue();
+      await route.fulfill({ status: 413, contentType: 'text/plain', body: 'Payload Too Large' });
+    });
+
+    await page.getByPlaceholder('Grace Hopper').fill('Grace Hopper');
+    await page.getByPlaceholder('grace@example.com').fill('grace@example.com');
+    await page.getByRole('button', { name: 'Add user' }).click();
+
+    const notice = page.locator('.notice.error');
+    await expect(notice).toContainText('413');
+    await expect(notice).toContainText('Payload Too Large');
+    await expect(notice).not.toContainText('Connection closed');
+    // The page is still the page: a failed action must not take the tree down with it.
+    await expect(page.getByText('Ada Lovelace')).toBeVisible();
+  });
+
   test('a rejected action surfaces its message instead of tearing down the page', async ({ page }) => {
     await page.goto('/users');
 

--- a/packages/core/test/cloudflare.test.mjs
+++ b/packages/core/test/cloudflare.test.mjs
@@ -182,6 +182,24 @@ describe('serving from a Worker', () => {
     assert.equal(await second.text(), '');
   });
 
+  test('does not ask the store for a page the build never prerendered', async () => {
+    // Every miss here is a subrequest, and misses are deliberately not cached — so a static route the
+    // build wrote nothing for would spend one on every request, forever. The build's manifest is what
+    // answers instead; it is fetched once per isolate, which is why it is allowed in the list below.
+    const asked = [];
+    const counting = { fetch: (request) => (asked.push(new URL(request.url).pathname), ASSETS.fetch(request)) };
+    const res = await worker.fetch(new Request(`${ORIGIN}/docs/never-prerendered`), { ASSETS: counting, ...APP_ENV }, {
+      waitUntil() {},
+      passThroughOnException() {},
+    });
+    await res.text();
+
+    assert.equal(res.status, 200, 'the route still renders per request');
+    assert.equal(res.headers.get('cache-control'), 'private, no-cache', 'rendered, not served from the store');
+    const pageReads = asked.filter((p) => p.startsWith('/__ssg/') && !p.endsWith('/manifest.json'));
+    assert.deepEqual(pageReads, [], 'the index already says there is no page under that path');
+  });
+
   test('serves a public/ file through the binding', async () => {
     const res = await fetchWorker('/robots.txt');
     assert.equal(res.status, 200);

--- a/packages/core/test/cloudflare.test.mjs
+++ b/packages/core/test/cloudflare.test.mjs
@@ -153,6 +153,17 @@ describe('serving from a Worker', () => {
     assert.match(res.headers.get('etag') ?? '', /^W\//, 'weak: something in front may re-encode the bytes without changing the representation');
   });
 
+  test('serves a percent-encoded slug out of the store the filesystem targets read by name', async () => {
+    // One build, one on-disk name, every target: the store is addressed by URL here and by file name
+    // elsewhere, and the two used to resolve a non-ASCII slug differently — a hit on Workers and a
+    // permanent miss on node, vercel and aws-lambda, from the same `dist/`.
+    const res = await fetchWorker('/docs/caf%C3%A9');
+    const body = await res.text();
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=300', 'served from the build, not re-rendered');
+    assert.match(body, /Café/);
+  });
+
   test('answers the same URL with the prerendered flight payload when asked for one', async () => {
     const res = await fetchWorker('/docs/getting-started', { headers: { RSC: '1' } });
     const body = await res.text();

--- a/packages/core/test/dev.test.mjs
+++ b/packages/core/test/dev.test.mjs
@@ -9,8 +9,24 @@ import { runCli, startTestbed, stopServer, TESTBED_DEV_DIR, TESTBED_DIR } from '
 
 // Served under the testbed's hardened profile, so the dev-only half of the CSP contract is covered
 // here: the app writes one policy for both environments and the framework widens it for React Refresh.
-const { base, child, port } = await startTestbed('dev', { timeoutMs: 90_000, env: { TESTBED_CSP: '1' } });
+const { base, child, port, getOutput } = await startTestbed('dev', { timeoutMs: 90_000, env: { TESTBED_CSP: '1' } });
 after(() => stopServer(child));
+
+// A `redirect()` from a boundary that resolves after the shell cannot become a 3xx — the response is
+// already committed (see the README's "Requirements & limitations"). The fix is in app code, so the
+// framework says so where the app is being written. Production stays silent; prod.test.mjs asserts that.
+test('dev warns when a control signal arrives after the page shell has been sent', async () => {
+  const logsBefore = getOutput().length;
+  const res = await fetch(`${base}/late-signal`, { redirect: 'manual' });
+  await res.text();
+  assert.equal(res.status, 200, 'the degradation itself is the documented behaviour');
+
+  await new Promise((resolve) => setTimeout(resolve, 300)); // the child's stderr reaches us asynchronously
+  const logged = getOutput().slice(logsBefore);
+  assert.match(logged, /resolved after the page shell had already been sent/, 'the author has to be told');
+  assert.match(logged, /GET \/late-signal/, 'and which request it was');
+  assert.match(logged, /middleware/, 'and where the decision belongs instead');
+});
 
 test('dev serves both representations of a page through the worker proxy', async () => {
   const document = await fetch(`${base}/`);

--- a/packages/core/test/minimal-app.test.mjs
+++ b/packages/core/test/minimal-app.test.mjs
@@ -54,10 +54,15 @@ test('with no notFound page, an unmatched path is a plain 404', async () => {
   assert.equal(res.status, 404);
   assert.match(res.headers.get('content-type'), /text\/plain/);
   assert.match(res.headers.get('vary'), /\bRSC\b/, 'the same URL answers differently per the RSC header');
+  // A 404 is heuristically cacheable, and this one is `text/plain` — so it misses the default the framework
+  // applies to page content types, and has to carry it itself. A rendered HTML 404 is `private, no-cache`;
+  // the same answer to the same request must not promise something else because of who asked.
+  assert.equal(res.headers.get('cache-control'), 'private, no-cache');
 });
 
 test('with no error page, a thrown page falls back to the framework 500 without leaking the message', async () => {
   const res = await fetch(`${base}/boom`, { headers: { Accept: 'text/html' } });
+  assert.equal(res.headers.get('cache-control'), 'private, no-cache', 'the framework’s own answers agree about caching');
   assert.equal(res.status, 500);
   const body = await res.text();
   assert.match(body, /Internal Server Error/);

--- a/packages/core/test/minimal-app.test.mjs
+++ b/packages/core/test/minimal-app.test.mjs
@@ -119,6 +119,15 @@ test('a browser-shaped form post from another origin cannot reach a server actio
     assert.notEqual(sameOrigin.status, 403, `${site} labelled, but posted from the app itself`);
   }
 
+  // Neither the label with no `Origin` at all nor `Origin: null` — a sandboxed iframe, a `data:` URL,
+  // `Referrer-Policy: no-referrer` — proves this came from here. A browser attaches an `Origin` to every
+  // non-GET request, so neither is a shape one produces; the guard says "proven local" rather than "not
+  // proven foreign" so that stays true of it the day something does.
+  const noOrigin = await post({ 'sec-fetch-site': 'cross-site' });
+  assert.equal(noOrigin.status, 403, 'a cross-site label with no Origin proves nothing');
+  const opaque = await post({ origin: 'null', 'sec-fetch-site': 'cross-site' });
+  assert.equal(opaque.status, 403, 'an opaque origin is not the app');
+
   // `same-origin` is the browser's own statement that this came from the app's own pages, and it is
   // unforgeable by page script — so it settles the question whatever `Origin` says. That short-circuit is
   // what keeps a proxy that rewrites `Host` from breaking every legitimate post behind it.

--- a/packages/core/test/minimal-app.test.mjs
+++ b/packages/core/test/minimal-app.test.mjs
@@ -3,8 +3,7 @@
 // `defineRoutes` shorthand. The rest of the suite runs against one richly-configured testbed, which
 // is exactly the app that would never catch "the framework assumes X exists".
 import assert from 'node:assert/strict';
-import { cpSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { after, test } from 'node:test';
 import { buildApp, MINIMAL_APP_DIR, runCli, startApp, stopServer } from './helpers.mjs';
@@ -146,18 +145,29 @@ test('a browser-shaped form post from another origin cannot reach a server actio
 // the developer has to open, or — for the duplicate path — a clean exit 0 with the second entry dead.
 const throwaway = [];
 after(() => {
-  for (const dir of throwaway) {
-    // The link, not what it points at: `node_modules` is the fixture's, borrowed rather than copied.
-    unlinkSync(join(dir, 'node_modules'));
-    rmSync(dir, { recursive: true, force: true });
-  }
+  for (const dir of throwaway) rmSync(dir, { recursive: true, force: true });
 });
 
-/** The minimal app somewhere disposable, with `src/routes.ts` replaced — a build that must fail, run safely. */
+/**
+ * The minimal app with `src/routes.ts` replaced, somewhere disposable — a build that must fail, run safely.
+ *
+ * **Inside the fixture**, not in the OS temp directory, and with no `node_modules` of its own: these two
+ * cases run a real Rspack build, and `@rshono/core` is the one package it cannot resolve from the
+ * *framework's* `node_modules` — it is reachable only through the app's. Nesting the copy one level down
+ * means the resolver walks up and finds the fixture's real `node_modules`, with no link of any kind in the
+ * way.
+ *
+ * That link used to be a Windows-only build failure. A `'junction'` to the fixture's `node_modules` from a
+ * temp directory on another volume is not traversed by the bundler's resolver there, so the build died on
+ * `Can't resolve '@rshono/core'` before it could reach the validation these cases are about — while
+ * `react` and `hono`, which the framework's own `node_modules` answers for, resolved fine and hid the
+ * shape of it.
+ *
+ * The directory is a sibling of `src/`, so nothing that scans the fixture's pages can see it.
+ */
 function appWithRoutes(routesSource) {
-  const dir = mkdtempSync(join(tmpdir(), 'rshono-invalid-'));
+  const dir = mkdtempSync(join(MINIMAL_APP_DIR, 'throwaway-'));
   throwaway.push(dir);
-  symlinkSync(join(MINIMAL_APP_DIR, 'node_modules'), join(dir, 'node_modules'), 'junction');
   cpSync(join(MINIMAL_APP_DIR, 'package.json'), join(dir, 'package.json'));
   cpSync(join(MINIMAL_APP_DIR, 'src', 'pages'), join(dir, 'src', 'pages'), { recursive: true });
   writeFileSync(join(dir, 'src', 'routes.ts'), routesSource);

--- a/packages/core/test/minimal-app.test.mjs
+++ b/packages/core/test/minimal-app.test.mjs
@@ -89,27 +89,41 @@ test('with no server.ts there is no CSRF check — that is `csrf()` from hono, a
   assert.notEqual(res.status, 403, 'nothing in the framework rejects this any more');
 });
 
-test('a browser-shaped cross-site form post cannot reach a server action, even with no server.ts', async () => {
+test('a browser-shaped form post from another origin cannot reach a server action, even with no server.ts', async () => {
   // The one place the framework does refuse: a form post is the only action shape a browser can be made to
   // send from another site — the client-initiated one carries `x-rsc-action`, which needs a preflight it will
   // not get. So this is not a CSRF policy stepping on `csrf()`'s toes; it is the framework declining to run
   // its own action mechanism for a request that mechanism cannot produce. An app *with* src/server.ts has
   // `csrf()` in front of this, which rejects the same request first and for better reasons.
-  const res = await fetch(`${base}/`, {
-    method: 'POST',
-    headers: { origin: 'https://evil.test', 'sec-fetch-site': 'cross-site', 'content-type': 'application/x-www-form-urlencoded' },
-    body: 'x=1',
-  });
-  assert.equal(res.status, 403);
+  const post = (headers) =>
+    fetch(`${base}/`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
+      body: 'x=1',
+    });
 
-  // And the pair a browser never sends — cross-site label, the app's own origin — is left alone, or a proxy
-  // that sets the label by hand would break every legitimate form post behind it.
-  const sameOrigin = await fetch(`${base}/`, {
-    method: 'POST',
-    headers: { origin: base, 'sec-fetch-site': 'cross-site', 'content-type': 'application/x-www-form-urlencoded' },
-    body: 'x=1',
-  });
-  assert.notEqual(sameOrigin.status, 403);
+  const crossSite = await post({ origin: 'https://evil.test', 'sec-fetch-site': 'cross-site' });
+  assert.equal(crossSite.status, 403);
+
+  // `same-site` is the label a *sibling subdomain* gets — a user-content host, a stale CNAME, a subdomain
+  // takeover. It used to be left to `csrf()` on the grounds that a subdomain policy is `csrf()`'s to
+  // express, which for an app that has no `csrf()` meant any `'use server'` export could be driven from
+  // next door with any arguments.
+  const subdomain = await post({ origin: 'https://user-content.evil.test', 'sec-fetch-site': 'same-site' });
+  assert.equal(subdomain.status, 403, 'a sibling subdomain is another origin');
+
+  // And the pair a browser never sends — a not-from-here label with the app's own origin — is left alone, or
+  // a proxy that sets the label by hand would break every legitimate form post behind it.
+  for (const site of ['cross-site', 'same-site']) {
+    const sameOrigin = await post({ origin: base, 'sec-fetch-site': site });
+    assert.notEqual(sameOrigin.status, 403, `${site} labelled, but posted from the app itself`);
+  }
+
+  // `same-origin` is the browser's own statement that this came from the app's own pages, and it is
+  // unforgeable by page script — so it settles the question whatever `Origin` says. That short-circuit is
+  // what keeps a proxy that rewrites `Host` from breaking every legitimate post behind it.
+  const genuine = await post({ origin: 'https://rewritten-by-proxy.test', 'sec-fetch-site': 'same-origin' });
+  assert.notEqual(genuine.status, 403, 'the browser said this came from the app itself');
 });
 
 // What the framework *refuses*, which for this app is the other half of the same claim: `src/routes.ts`

--- a/packages/core/test/minimal-app.test.mjs
+++ b/packages/core/test/minimal-app.test.mjs
@@ -3,8 +3,11 @@
 // `defineRoutes` shorthand. The rest of the suite runs against one richly-configured testbed, which
 // is exactly the app that would never catch "the framework assumes X exists".
 import assert from 'node:assert/strict';
+import { cpSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { after, test } from 'node:test';
-import { buildApp, MINIMAL_APP_DIR, startApp, stopServer } from './helpers.mjs';
+import { buildApp, MINIMAL_APP_DIR, runCli, startApp, stopServer } from './helpers.mjs';
 
 buildApp(MINIMAL_APP_DIR);
 const { base, child, port } = await startApp(MINIMAL_APP_DIR, 'start');
@@ -107,4 +110,48 @@ test('a browser-shaped cross-site form post cannot reach a server action, even w
     body: 'x=1',
   });
   assert.notEqual(sameOrigin.status, 403);
+});
+
+// What the framework *refuses*, which for this app is the other half of the same claim: `src/routes.ts`
+// and `src/server.ts` are the two modules it cannot type-check, so both are validated at load. Each of
+// these used to be either a `TypeError` from inside a minified bundle, naming neither rshono nor the file
+// the developer has to open, or — for the duplicate path — a clean exit 0 with the second entry dead.
+const throwaway = [];
+after(() => {
+  for (const dir of throwaway) {
+    // The link, not what it points at: `node_modules` is the fixture's, borrowed rather than copied.
+    unlinkSync(join(dir, 'node_modules'));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** The minimal app somewhere disposable, with `src/routes.ts` replaced — a build that must fail, run safely. */
+function appWithRoutes(routesSource) {
+  const dir = mkdtempSync(join(tmpdir(), 'rshono-invalid-'));
+  throwaway.push(dir);
+  symlinkSync(join(MINIMAL_APP_DIR, 'node_modules'), join(dir, 'node_modules'), 'junction');
+  cpSync(join(MINIMAL_APP_DIR, 'package.json'), join(dir, 'package.json'));
+  cpSync(join(MINIMAL_APP_DIR, 'src', 'pages'), join(dir, 'src', 'pages'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'routes.ts'), routesSource);
+  return dir;
+}
+
+const HOME_AND = (second) =>
+  `import { defineRoutes } from '@rshono/core';\nexport const routes = defineRoutes([\n  { path: '/', component: () => import('./pages/home') },\n${second}]);\n`;
+
+test('a second route claiming a path the table already answers fails the build, naming both entries', () => {
+  const dir = appWithRoutes(HOME_AND("  { path: '/', component: () => import('./pages/manual') },\n"));
+  const { status, output } = runCli(dir, ['build']);
+  assert.equal(status, 1, `the build must not exit 0:\n${output}`);
+  assert.match(output, /\[rshono\] src\/routes\.ts: routes\[1\] \("\/"\) would never run — routes\[0\] \("\/"\) already answers GET, POST \//);
+  assert.doesNotMatch(output, /is not iterable|Cannot read properties/, 'and not by handing over a TypeError from a minified bundle');
+});
+
+test('a src/server.ts that does not default-export a Hono app fails the build, naming the file', () => {
+  const dir = appWithRoutes(HOME_AND(''));
+  writeFileSync(join(dir, 'src', 'server.ts'), 'export default { notAHono: true };\n');
+  const { status, output } = runCli(dir, ['build']);
+  assert.equal(status, 1, `the build must not exit 0:\n${output}`);
+  assert.match(output, /\[rshono\] src\/server\.ts must `export default` a Hono app/);
+  assert.doesNotMatch(output, /Cannot read properties of undefined/, "Hono's own failure names nothing the developer wrote");
 });

--- a/packages/core/test/prod-config.test.mjs
+++ b/packages/core/test/prod-config.test.mjs
@@ -64,6 +64,25 @@ describe('a hardened server.ts', () => {
     assert.match(header, /script-src [^;]*'nonce-/);
   });
 
+  test("the app's own middleware reaches /_static, so an asset carries HSTS and the app's policy", async () => {
+    // The hashed bundle used to be mounted *ahead* of src/server.ts, and it is a terminal handler — so
+    // `/_static/*` was answered by something none of the app's middleware ever saw. HSTS is the one that
+    // materially matters: it is per-response, and a `/_static` request over http is exactly where a
+    // downgrade lands. CSP and COOP are moot for a .js file, but their absence is not what an operator
+    // reading their own `secureHeaders()` call expects.
+    const html = await (await fetch(`${app.base}/`)).text();
+    const asset = html.match(/src="(\/_static\/chunks\/main\.[0-9a-f]+\.js)"/)[1];
+    const res = await fetch(app.base + asset);
+    await res.text();
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('strict-transport-security'), 'an asset response is missing HSTS');
+    assert.ok(res.headers.get('content-security-policy'), "…and the app's policy");
+    assert.ok(res.headers.get('x-response-time'), "the app's own middleware did not run for the asset");
+    // And the asset's own cache policy still wins: this is the app's middleware wrapping the handler,
+    // not replacing it.
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=31536000, immutable');
+  });
+
   test('the prerendered flight payload is still served from disk — only the document needs a nonce', async () => {
     // A flight payload never carries a nonce (that only goes on the HTML bootstrap), so there is
     // nothing per-request about it and no reason for CSP to cost soft navigations their prerender.

--- a/packages/core/test/prod-config.test.mjs
+++ b/packages/core/test/prod-config.test.mjs
@@ -208,3 +208,34 @@ describe('a server.ts with no csrf()', () => {
     assert.notEqual(res.status, 403, 'with no csrf() middleware, a cross-origin action must not be rejected');
   });
 });
+
+// `SSG_CACHE_CONTROL` is `public, max-age=300` and has no config field, deliberately — it is a
+// per-response header and `rshono.config.ts` is compiled into the bundle. Middleware is the interface,
+// and the one thing a reader has to be told is *where* in the middleware it goes.
+describe('a server.ts that overrides the prerendered cache policy', () => {
+  const app = serve({ TESTBED_SSG_CACHE: '1' });
+
+  test('a header set after `await next()` replaces the framework default; one set before it does not', async () => {
+    const res = await fetch(`${app.base}/docs/getting-started`);
+    await res.text();
+    assert.equal(res.status, 200);
+    // The middleware sets `public, max-age=1` before `await next()` and the real value after it. Only the
+    // second lands: the SSG path builds its response with `cache-control` in the bag it hands `c.body(...)`,
+    // which replaces a header prepared with `c.header(...)`. That is why the recipe has to say "after".
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=86400, stale-while-revalidate=604800');
+    assert.ok(res.headers.get('etag'), 'a header edit, not a re-render — the prerendered ETag is untouched');
+    assert.equal(res.headers.get('vary'), 'RSC', 'and so is the Vary that makes one URL two answers');
+  });
+
+  test('the flight payload of the same page is overridden too, since both come off the same path', async () => {
+    const res = await fetch(`${app.base}/docs/getting-started`, { headers: { RSC: '1' } });
+    await res.text();
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=86400, stale-while-revalidate=604800');
+  });
+
+  test('a dynamic page outside the middleware keeps `private, no-cache`', async () => {
+    const res = await fetch(`${app.base}/`);
+    await res.text();
+    assert.equal(res.headers.get('cache-control'), 'private, no-cache', 'the default must not be widened for everything');
+  });
+});

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -279,10 +279,17 @@ test('a notFound page that redirects is honoured from both places a 404 is rende
   }
 });
 
-test('non-HTML clients get plain-text 404s', async () => {
+test('non-HTML clients get plain-text 404s, private like the rendered one', async () => {
   const res = await fetch(`${base}/api/definitely-not-an-endpoint`);
   assert.equal(res.status, 404);
   assert.equal(await res.text(), 'Not Found');
+  // `text/plain`, so the default the framework applies to page content types does not reach it — and a 404
+  // is heuristically cacheable, so a shared cache is free to store one that says nothing.
+  assert.equal(res.headers.get('cache-control'), 'private, no-cache');
+
+  const rendered = await fetch(`${base}/definitely-not-a-page`, { headers: { Accept: 'text/html' } });
+  await rendered.text();
+  assert.equal(rendered.headers.get('cache-control'), res.headers.get('cache-control'), 'the two 404s must agree');
 });
 
 test('useNavigation() gives a client island server-computed pathname/params/searchParams during SSR (no flicker)', async () => {

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -444,6 +444,21 @@ test('a HEAD on a prerendered route is served from the store, ETag and all', asy
   assert.equal(revalidated.status, 304, 'and that validator has to work');
 });
 
+test('an endpoint route answers every method it lists, and nothing else', async () => {
+  // `Origin`, because the testbed registers `csrf()`: it refuses an unsafe method with a foreign origin
+  // long before the router is reached, and a 403 would say nothing about routing.
+  for (const method of ['GET', 'DELETE']) {
+    const res = await fetch(`${base}/api/session`, { method, headers: { Origin: base } });
+    assert.equal(res.status, 200, `${method} is listed, so it must reach the handler`);
+    assert.deepEqual(await res.json(), { method }, 'one handler answers both');
+  }
+  for (const method of ['POST', 'PUT']) {
+    const res = await fetch(`${base}/api/session`, { method, headers: { Accept: 'text/html', Origin: base } });
+    await res.text();
+    assert.equal(res.status, 404, `${method} is not listed, so it must not reach the handler`);
+  }
+});
+
 test("a HEAD on a method: 'get' endpoint is answered by that handler, bodiless", async () => {
   // Why `HTTPMethod` has no `'head'`: Hono dispatches a HEAD as a GET and strips the body, so `'get'`
   // answers both — and a route registered for HEAD alone answers neither, not even the GET.

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -430,6 +430,22 @@ test('the build writes both representations of a static route', () => {
   assert.match(readFileSync(join(dir, 'index.rsc'), 'utf8'), /Getting Started/);
 });
 
+test('a slug that has to be percent-encoded is written where the request for it resolves', async () => {
+  // The half that used to be missing. The build interpolated the value with `encodeURIComponent` and wrote
+  // `docs/caf%C3%A9/`, while Hono hands the handler a `c.req.path` it has already run `decodeURI` over — so
+  // the page was reported as prerendered and every request for it silently fell back to SSR, forever.
+  const dir = join(TESTBED_DIST, 'ssg', 'docs', 'café');
+  assert.match(readFileSync(join(dir, 'index.html'), 'utf8'), /pre-rendered at build time/, 'stored under the decoded name');
+
+  for (const { name, headers } of REPRESENTATIONS) {
+    const res = await fetch(`${base}/docs/caf%C3%A9`, { headers });
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get('etag'), `${name}: served from the build, not re-rendered per request`);
+    assert.match(res.headers.get('cache-control') ?? '', /public/, `${name}: a prerendered page is publicly cacheable`);
+    assert.match(await res.text(), /Café/);
+  }
+});
+
 test('a prerendered route is served from disk in both representations, publicly cacheable and revalidatable', async () => {
   // Prerendering used to pay off only for cold loads and crawlers: a flight request skipped the built
   // file and re-rendered the page the build had already produced.

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -216,6 +216,33 @@ test('an unmatched path renders the notFound page from routes.ts, as a document 
   assert.match(await flight.text(), /nothing here/, 'a soft navigation swaps the 404 page in instead of reloading');
 });
 
+// A `notFound` page that throws is the one failure with nowhere to escalate to: it renders from `onError`
+// as well as from the page handler, and Hono calls `onError` inside its own catch — so a throw from there
+// used to reject `app.fetch` and be answered by the host with a bodiless 500 that nothing logged.
+// `?boom=` makes the testbed's 404 page fail on demand; see components/404.tsx.
+test('a notFound page that throws notFound() answers a 404 with a body, and says so in the log', async () => {
+  for (const path of ['/definitely-not-a-page', '/profile/9999']) {
+    const logsBefore = getOutput().length;
+    const res = await fetch(`${base}${path}?boom=notfound`, { headers: { Accept: 'text/html' } });
+
+    assert.equal(res.status, 404, `${path}: still a 404, just without the app's page`);
+    assert.equal(await res.text(), 'Not Found', `${path}: a body, not the host's empty 500`);
+
+    await new Promise((resolve) => setTimeout(resolve, 200)); // the child's stderr reaches us asynchronously
+    assert.match(getOutput().slice(logsBefore), /the notFound page failed to render/, `${path}: and it is reported`);
+  }
+});
+
+test('a notFound page that redirects is honoured from both places a 404 is rendered', async () => {
+  // Not a failure at all: nothing is committed when the signal arrives, and `app.notFound` has always
+  // answered it this way — so the path through the page handler has to agree rather than degrade.
+  for (const path of ['/definitely-not-a-page', '/profile/9999']) {
+    const res = await fetch(`${base}${path}?boom=redirect`, { headers: { Accept: 'text/html' }, redirect: 'manual' });
+    assert.equal(res.status, 303, path);
+    assert.match(res.headers.get('location') ?? '', /\/users$/, path);
+  }
+});
+
 test('non-HTML clients get plain-text 404s', async () => {
   const res = await fetch(`${base}/api/definitely-not-an-endpoint`);
   assert.equal(res.status, 404);

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -577,6 +577,9 @@ test('baseline security headers are set on every response', async () => {
 
 test('secrets never reach the browser — not in the HTML, the flight payload, or a client chunk', async () => {
   const html = await (await fetch(`${base}/`)).text();
+  // `leak-helper.ts` reaches the env three ways and never once by the dotted spelling the shadow used to be
+  // gated on — `process?.env`, `process['env']` and an alias. Each of them rendered the real value here while
+  // the browser bundle saw the `PUBLIC_`-only view; the loader unit tests hold the whole table.
   assert.match(html, /Using leak helper:\s*(?:<!--\s*-->)?\(no secret\)/, 'no-directive helper leaked a real secret into SSR HTML');
   assert.ok(!html.includes(APP_ENV.DATABASE_URL), 'DATABASE_URL value must not appear in SSR HTML');
   assert.ok(html.includes(APP_ENV.PUBLIC_API_ENDPOINT), 'the PUBLIC_ variable should be inlined');

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -436,6 +436,19 @@ test('a method a page route does not answer is a 404, not a 405', async () => {
   const options = await fetch(`${base}/api/boom`, { method: 'OPTIONS', headers: { Origin: base } });
   await options.text();
   assert.equal(options.status, 500, 'an endpoint route with no method of its own answers every one of them');
+
+  // And it can name that method rather than taking every one: `method: 'options'` is how an app answers
+  // the CORS preflight a cross-origin action needs, which no page route ever will.
+  const preflight = await fetch(`${base}/api/preflight`, { method: 'OPTIONS', headers: { Origin: 'https://admin.example' } });
+  await preflight.text();
+  assert.equal(preflight.status, 204);
+  assert.equal(preflight.headers.get('access-control-allow-methods'), 'POST, OPTIONS');
+  assert.equal(preflight.headers.get('access-control-allow-origin'), 'https://admin.example');
+
+  // …and only that method: the same path asked for as a page is the notFound page.
+  const asPage = await fetch(`${base}/api/preflight`, { headers: { Accept: 'text/html' } });
+  await asPage.text();
+  assert.equal(asPage.status, 404, 'an endpoint that names one method answers only that one');
 });
 
 // A HEAD promises the headers its GET would send, so it takes the same path — including the prerendered

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -109,6 +109,29 @@ test('getRequestContext() exposes url/pathname, headers, cookies and env in an a
   assert.ok(html.includes(APP_ENV.PUBLIC_API_ENDPOINT), 'ctx.env did not expose the PUBLIC_ variable');
 });
 
+// The request context is one of the four boundaries SECURITY.md owns, and every other test of it is
+// sequential — so nothing proved that two in-flight requests do not see each other's. `/whoami` is the
+// page for it: it awaits before reading the context, so the `AsyncLocalStorage` store has to survive a
+// real suspension, and it echoes a request header back into the document.
+test('two concurrent requests keep separate request contexts', async () => {
+  const marks = Array.from({ length: 8 }, (_, index) => `concurrent-${index}`);
+  const documents = await Promise.all(
+    marks.map(async (mark) => {
+      const res = await fetch(`${base}/whoami`, { headers: { 'x-test': mark, cookie: `visitor=${mark}-cookie` } });
+      assert.equal(res.status, 200);
+      return { mark, html: await res.text() };
+    }),
+  );
+
+  for (const { mark, html } of documents) {
+    assert.match(html, new RegExp(mark), `${mark}: the response must carry its own header value`);
+    assert.match(html, new RegExp(`${mark}-cookie`), `${mark}: …and its own cookie`);
+    for (const other of marks.filter((m) => m !== mark)) {
+      assert.doesNotMatch(html, new RegExp(`\\b${other}\\b`), `${mark}: another request's context leaked into it (${other})`);
+    }
+  }
+});
+
 test('the ctx page prop is the request context, without importing getRequestContext()', async () => {
   const res = await fetch(`${base}/`, { headers: { cookie: 'visitor=Ada%20Lovelace' } });
   assert.equal(res.status, 200);

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -400,6 +400,40 @@ test('a thrown server action is redacted in the payload, but logged in full serv
   assert.match(logged, /A name and a valid email are required/, 'the real error message must reach the server log — it is the only signal left');
 });
 
+// An action and the page it answers with are one response, so a render that fails *after* the action ran
+// takes the action's reply with it unless the result is carried across. `/unloadable` is a page whose module
+// throws as it evaluates — a chunk that went missing between deploys, from the runtime's side.
+test('an action whose page then fails to load still gets its result back', async () => {
+  const res = await fetch(`${base}/unloadable`, {
+    method: 'POST',
+    headers: { Origin: base, 'x-rsc-action': serverActionId('Add user'), RSC: '1', 'content-type': 'text/plain;charset=UTF-8' },
+    body: JSON.stringify([{ name: 'Drift Dana', email: 'dana@example.com' }]),
+  });
+
+  assert.equal(res.status, 500);
+  assert.match(res.headers.get('content-type'), /text\/x-component/, 'the client is holding a live tree, so the reply is still a payload');
+  const payload = await res.text();
+  assert.match(payload, /"returnValue":\{"ok":true/, 'the action ran and its result is the caller’s, error page or not');
+  assert.match(payload, /Drift Dana/, 'including the value it returned');
+  assert.match(payload, /Something went wrong/, 'and the page it comes with is the app’s error page');
+});
+
+test('an action request that fails before the action runs answers with a payload carrying no result', async () => {
+  // The other half: nothing ran, so there is nothing to carry. What matters is that the reply is still a
+  // payload the client can decode — it is what lets the runtime say so, instead of reading `.ok` off it.
+  const res = await fetch(`${base}/users`, {
+    method: 'POST',
+    headers: { Origin: base, 'x-rsc-action': serverActionId('Add user'), RSC: '1', 'content-type': 'text/plain;charset=UTF-8' },
+    body: 'not-a-flight-reply',
+  });
+
+  assert.equal(res.status, 500);
+  assert.match(res.headers.get('content-type'), /text\/x-component/);
+  const payload = await res.text();
+  assert.doesNotMatch(payload, /"returnValue":\{/, 'the action never ran, so no result may be invented for it');
+  assert.match(payload, /Something went wrong/);
+});
+
 test('onServerError sees the errors the framework catches, tagged by source, without replacing the log', async () => {
   const logsBefore = getOutput().length;
 

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -138,13 +138,16 @@ test('redirect() in a server component: an HTTP 3xx on hard navigation, a digest
   assert.match(await soft.text(), /RSHONO_REDIRECT/, 'the client needs the digest to follow the redirect itself');
 });
 
-test('redirect() from inside a bare Suspense, after the shell has already resolved', async () => {
-  // `/dashboard` above redirects from the page component, so the signal arrives before there is a response to
-  // abandon. This is the other window: a bare `<Suspense>` has no `CatchBoundary` to re-throw the signal, so
-  // React SSR renders the fallback, the shell resolves, and the HTML response is live and being pumped by the
-  // time the RSC render records the redirect. The framework has to drop that half-built response and answer
-  // with the redirect — which it does by aborting the render, cancelling the stream it will not serve, and
-  // re-throwing. Nothing exercised this path before.
+test('redirect() from a bare Suspense that settles just before the shell is ready is still a real 3xx', async () => {
+  // `/dashboard` above redirects from the page component, so the signal arrives before there is anything to
+  // abandon at all. This is the narrow window after that: a bare `<Suspense>` has no `CatchBoundary` to
+  // re-throw the signal, so React SSR renders the fallback and the shell resolves — but the section awaits
+  // only `Promise.resolve()`, so the signal is recorded before `renderHTML` hands its stream back and the
+  // response head is still the framework's to write. It drops the half-built response by aborting the render,
+  // cancelling the stream it will not serve, and re-throwing.
+  //
+  // The window *past* this one — a boundary that resolves later — cannot answer 3xx at all; that is
+  // `/late-signal` below.
   const hard = await fetch(`${base}/suspense-redirect`, { redirect: 'manual' });
   assert.equal(hard.status, 303, 'a hard load must still get a real redirect, not a half-rendered document');
   assert.match(hard.headers.get('location') ?? '', /\/login$/);
@@ -154,6 +157,39 @@ test('redirect() from inside a bare Suspense, after the shell has already resolv
   assert.equal(soft.status, 200, 'a flight fetch never reaches the SSR half, so the signal rides the payload');
   assert.match(await soft.text(), /RSHONO_REDIRECT/);
 });
+
+// The documented limitation, and the two things the framework still owes a request that hits it: the digest
+// has to survive, because it is the client's only way back, and the render nobody will read has to stop.
+// `/late-signal` waits 50ms before signalling — long past shell-ready — beside a second boundary that takes
+// 2s, which is what makes "the render was wound down" observable from outside.
+for (const { signal, digest, name } of [
+  { signal: null, digest: /RSHONO_REDIRECT;303;%2Flogin/, name: 'redirect()' },
+  { signal: 'notfound', digest: /RSHONO_NOT_FOUND/, name: 'notFound()' },
+]) {
+  test(`${name} from a boundary that resolves after the shell degrades to a 200 carrying the digest`, async () => {
+    const logsBefore = getOutput().length;
+    const started = Date.now();
+    const res = await fetch(`${base}/late-signal${signal ? `?signal=${signal}` : ''}`, { redirect: 'manual' });
+    const html = await res.text();
+    const elapsed = Date.now() - started;
+
+    assert.equal(res.status, 200, 'the head went out with the shell, and HTTP has no take-backs');
+    assert.match(res.headers.get('content-type'), /text\/html/);
+    assert.match(html, digest, 'the digest is the client’s only way back — aborting must not cut React off before it');
+    assert.match(html, /\$RX/, 'the pending boundaries are client-render instructions, not a truncated document');
+    assert.ok(html.trimEnd().endsWith('</body></html>'), 'and the document is closed properly');
+    assert.match(html, /data-section="loading"/, 'a visitor without JavaScript is left on the fallback — the limitation, documented in the README');
+
+    // The wind-down, from outside: the second boundary needs 2s, and neither its content nor that wait is here.
+    assert.doesNotMatch(html, /the slow section rendered anyway/, 'the render for a page nobody will read must stop');
+    assert.ok(elapsed < 1500, `the doomed render should be aborted, not waited out (took ${elapsed}ms)`);
+
+    // The warning that goes with this is for whoever is writing the page, and dev is where they are. It is
+    // asserted in dev.test.mjs; here the point is that production says nothing.
+    await new Promise((resolve) => setTimeout(resolve, 200)); // the child's stderr reaches us asynchronously
+    assert.doesNotMatch(getOutput().slice(logsBefore), /resolved after the page shell/);
+  });
+}
 
 test('a client-initiated action that redirects answers with a flight payload the runtime navigates on', async () => {
   // The other redirect shape, and the only one that reaches the RSC branch of `respondToControlSignal`.

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -376,6 +376,26 @@ test('endpoint route and Hono sub-app respond with JSON', async () => {
   assert.ok(Array.isArray(users.users) && users.users.length >= 3);
 });
 
+// The documented choice, pinned so it stays one: a page answers GET, POST and the HEAD that rides the GET,
+// and every other method is the notFound page rather than a 405 with an `Allow` header. An endpoint route is
+// how an app answers those — see the README's "Requirements & limitations".
+test('a method a page route does not answer is a 404, not a 405', async () => {
+  for (const method of ['PUT', 'PATCH', 'DELETE', 'OPTIONS']) {
+    // With the app's own Origin: the testbed registers `csrf()`, which refuses an unsafe method with a
+    // foreign one long before the router is reached — a 403 that would say nothing about routing.
+    const res = await fetch(`${base}/`, { method, headers: { Accept: 'text/html', Origin: base } });
+    await res.text();
+    assert.equal(res.status, 404, `${method} on a page`);
+    assert.equal(res.headers.get('allow'), null, 'no Allow header is promised, because no 405 is');
+  }
+
+  // The way out, and the reason 404 is defensible: an endpoint route answers whatever it registers, and
+  // `method` defaults to `all`. `/api/boom` throws by design, so its 500 *is* the proof that it ran.
+  const options = await fetch(`${base}/api/boom`, { method: 'OPTIONS', headers: { Origin: base } });
+  await options.text();
+  assert.equal(options.status, 500, 'an endpoint route with no method of its own answers every one of them');
+});
+
 // A HEAD promises the headers its GET would send, so it takes the same path — including the prerendered
 // bytes, which is the difference between reading a file and rendering a page it then throws away.
 test('a HEAD on a page route answers with the GET head and no body', async () => {

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -511,7 +511,7 @@ test('a no-JS (progressive-enhancement) action that throws renders the error pag
   // The two action paths have to agree about what happened. This one is re-thrown so the error page can
   // render, which also carries it into the top-level handler — where, without the reporter de-duplicating,
   // the same fault would arrive a second time as a `request`.
-  assert.match(logged, /\[error-reporter\] action \/crash: Intentional server-action failure/, 'a thrown PE action is an action');
+  assert.match(logged, /\[error-reporter\] action \/crash #[^:]+: Intentional server-action failure/, 'a thrown PE action is an action');
   assert.doesNotMatch(logged, /\[error-reporter\] request \/crash/, 'and one fault is reported once, whatever stages it crosses');
 });
 
@@ -575,9 +575,14 @@ test('onServerError sees the errors the framework catches, tagged by source, wit
   await new Promise((resolve) => setTimeout(resolve, 200)); // the child's stdout reaches us asynchronously
 
   const logged = getOutput().slice(logsBefore);
-  assert.match(logged, /\[error-reporter\] request \/api\/boom: Intentional endpoint failure/, 'a thrown endpoint must be reported');
+  assert.match(logged, /\[error-reporter\] request \/api\/boom #[^:]+: Intentional endpoint failure/, 'a thrown endpoint must be reported');
   assert.match(logged, /\[error-reporter\] (?:render|ssr) \/crash/, 'a failed render must be reported');
   assert.match(logged, /\[rshono\] request error:/, 'stderr stays the fallback signal even with a reporter wired up');
+  // The handler logs from inside `waitUntil` and reads `hono.var.requestId`, so both assertions above also
+  // prove the two reach a handler at all — and the `request` one proves it for the source reported outside
+  // the ambient context, where `getRequestContext()` throws. That was the whole gap: reporting is what this
+  // hook exists for, and on a serverless target a report with nothing holding the invocation open is cut off.
+  assert.doesNotMatch(logged, /#undefined/, 'the Hono context must carry the middleware variables, not an empty one');
 });
 
 test('<AsyncBoundary> renders its children on the happy path', async () => {

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -237,6 +237,14 @@ test('notFound() in a server component renders the 404 page', async () => {
   const res = await fetch(`${base}/profile/9999`, { headers: { Accept: 'text/html' } });
   assert.equal(res.status, 404);
   assert.match(await res.text(), /404 — nothing here/);
+
+  // A flight fetch is the other shape, and it is not a 404: `renderComponent` hands the payload stream back
+  // before the render can throw, so a `notFound()` from inside a component rides that payload as a digest —
+  // the response was committed the moment it was returned. The client runtime turns the digest into a real
+  // load, which is the 404 above. Same signal, same page, two ways of getting there.
+  const flight = await fetch(`${base}/profile/9999`, { headers: { RSC: '1' } });
+  assert.equal(flight.status, 200);
+  assert.match(await flight.text(), /RSHONO_NOT_FOUND/, 'the digest is what reaches the client, not a 404 payload');
 });
 
 test('an unmatched path renders the notFound page from routes.ts, as a document and as flight', async () => {
@@ -249,7 +257,11 @@ test('an unmatched path renders the notFound page from routes.ts, as a document 
   const flight = await fetch(`${base}/definitely-not-a-page`, { headers: { RSC: '1' } });
   assert.equal(flight.status, 404);
   assert.match(flight.headers.get('content-type'), /text\/x-component/);
-  assert.match(await flight.text(), /nothing here/, 'a soft navigation swaps the 404 page in instead of reloading');
+  const payload = await flight.text();
+  assert.match(payload, /nothing here/, 'a soft navigation swaps the 404 page in instead of reloading');
+  // The same page for the same status as the `notFound()` path below, so it has to say the same thing about
+  // itself: a client cannot tell the 404 page from the page it asked for by looking at the tree.
+  assert.match(payload, /"notFound":true/, 'the payload has to declare itself the not-found page');
 });
 
 // A `notFound` page that throws is the one failure with nowhere to escalate to: it renders from `onError`

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -313,6 +313,24 @@ test('endpoint route and Hono sub-app respond with JSON', async () => {
   assert.ok(Array.isArray(users.users) && users.users.length >= 3);
 });
 
+test("a HEAD on a method: 'get' endpoint is answered by that handler, bodiless", async () => {
+  // Why `HTTPMethod` has no `'head'`: Hono dispatches a HEAD as a GET and strips the body, so `'get'`
+  // answers both — and a route registered for HEAD alone answers neither, not even the GET.
+  const res = await fetch(`${base}/api/quick-health`, { method: 'HEAD' });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type'), /application\/json/);
+  assert.equal(await res.text(), '', 'a HEAD carries the headers and no body');
+
+  // The framework's own mounts have to hold the same way, now that they register `GET` alone.
+  const html = await (await fetch(`${base}/`)).text();
+  const chunk = html.match(/src="(\/_static\/chunks\/main\.[0-9a-f]+\.js)"/)[1];
+  for (const path of ['/robots.txt', chunk]) {
+    const asset = await fetch(`${base}${path}`, { method: 'HEAD' });
+    assert.equal(asset.status, 200, `${path} must answer a HEAD`);
+    assert.equal(await asset.text(), '', `${path}: a HEAD carries no body`);
+  }
+});
+
 test('a thrown endpoint renders the error page from routes.ts, redacted, in both representations', async () => {
   for (const { name, headers, contentType } of REPRESENTATIONS) {
     const res = await fetch(`${base}/api/boom`, { headers: { Accept: 'text/html', ...headers } });

--- a/packages/core/test/prod.test.mjs
+++ b/packages/core/test/prod.test.mjs
@@ -376,6 +376,35 @@ test('endpoint route and Hono sub-app respond with JSON', async () => {
   assert.ok(Array.isArray(users.users) && users.users.length >= 3);
 });
 
+// A HEAD promises the headers its GET would send, so it takes the same path — including the prerendered
+// bytes, which is the difference between reading a file and rendering a page it then throws away.
+test('a HEAD on a page route answers with the GET head and no body', async () => {
+  for (const path of ['/', '/docs/getting-started']) {
+    const head = await fetch(`${base}${path}`, { method: 'HEAD' });
+    const get = await fetch(`${base}${path}`);
+    const body = await get.text();
+
+    assert.equal(head.status, get.status, path);
+    assert.equal(await head.text(), '', `${path}: a HEAD carries no body`);
+    for (const header of ['content-type', 'cache-control', 'vary', 'etag', 'content-length']) {
+      assert.equal(head.headers.get(header), get.headers.get(header), `${path}: ${header} must be what the GET would send`);
+    }
+    assert.ok(body.length > 0, `${path}: the GET this mirrors is not empty`);
+  }
+});
+
+// The prerendered half of the same rule, asserted on its own because it is the one that used to render:
+// a static route answering a HEAD by rendering it carries no ETag, so a conditional HEAD could never 304.
+test('a HEAD on a prerendered route is served from the store, ETag and all', async () => {
+  const head = await fetch(`${base}/docs/getting-started`, { method: 'HEAD' });
+  assert.match(head.headers.get('cache-control'), /public, max-age=/, 'the prerendered cache policy, not the rendered one');
+  const etag = head.headers.get('etag');
+  assert.ok(etag, 'a prerendered answer carries its validator');
+
+  const revalidated = await fetch(`${base}/docs/getting-started`, { method: 'HEAD', headers: { 'if-none-match': etag } });
+  assert.equal(revalidated.status, 304, 'and that validator has to work');
+});
+
 test("a HEAD on a method: 'get' endpoint is answered by that handler, bodiless", async () => {
   // Why `HTTPMethod` has no `'head'`: Hono dispatches a HEAD as a GET and strips the body, so `'get'`
   // answers both — and a route registered for HEAD alone answers neither, not even the GET.

--- a/packages/core/test/start.test.mjs
+++ b/packages/core/test/start.test.mjs
@@ -12,7 +12,8 @@ import { describe, test } from 'node:test';
 
 const CLI = fileURLToPath(new URL('../bin/rshono.mjs', import.meta.url));
 
-const start = (cwd) => spawnSync(process.execPath, [CLI, 'start'], { cwd, encoding: 'utf8', timeout: 30_000 });
+const start = (cwd, { env = {}, args = [] } = {}) =>
+  spawnSync(process.execPath, [CLI, 'start', ...args], { cwd, encoding: 'utf8', timeout: 30_000, env: { ...process.env, ...env } });
 
 /**
  * A project directory holding what `rshono start` inspects: the server bundle it would spawn, and the
@@ -61,4 +62,45 @@ describe('`rshono start` runs what it can', () => {
     const result = start(projectWith({ deploy: 'node', bundle: 'process.exit(3);\n' }));
     assert.equal(result.status, 3, 'the exit code is the app’s, not swallowed');
   });
+});
+
+// The port is settled twice — once by the CLI, which puts it in the environment, and once by the bundle,
+// which binds it — so the two readings have to agree. `parsePort` is the single reading (unit-tested in
+// test/unit.test.mjs); these cover the CLI half: what it refuses, and what it hands on untouched.
+describe('`rshono start` and the port', () => {
+  /** A bundle that reports the environment the CLI left it, instead of binding anything. */
+  const echoPort = 'console.log("PORT=" + JSON.stringify(process.env.PORT));\n';
+
+  test('leaves an empty PORT alone, for the bundle to read as unset', () => {
+    const result = start(projectWith({ deploy: 'node', bundle: echoPort }), { env: { PORT: '' } });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /PORT=""/, 'not rewritten to 0 — that would bind a random port and report success');
+  });
+
+  test('passes a valid PORT and --port through, the flag winning', () => {
+    const project = projectWith({ deploy: 'node', bundle: echoPort });
+    assert.match(start(project, { env: { PORT: '4000' } }).stdout, /PORT="4000"/);
+    assert.match(start(project, { env: { PORT: '4000' }, args: ['--port', '8080'] }).stdout, /PORT="8080"/);
+    assert.match(start(project, { env: { PORT: '0' } }).stdout, /PORT="0"/, 'an explicit 0 means "any free port"');
+  });
+
+  for (const [label, value] of [
+    ['not a number', 'abc'],
+    ['out of range', '999999'],
+  ]) {
+    test(`refuses a PORT that is ${label}, before anything binds`, () => {
+      const result = start(projectWith({ deploy: 'node', bundle: echoPort }), { env: { PORT: value } });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /rshono: invalid PORT/, 'reported like every other bad CLI input');
+      assert.match(result.stderr, /0 and 65535/, 'and says what a port is');
+      assert.doesNotMatch(result.stderr, /\n\s+at /, 'one line, not a RangeError with a bundler frame in it');
+      assert.doesNotMatch(result.stdout, /PORT=/, 'the bundle never ran');
+    });
+
+    test(`refuses a --port that is ${label}`, () => {
+      const result = start(projectWith({ deploy: 'node', bundle: echoPort }), { args: ['--port', value] });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /rshono: invalid --port/);
+    });
+  }
 });

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -90,6 +90,23 @@ describe('injectFlightPayload', () => {
   test('carries the CSP nonce on the injected script', async () => {
     const html = await inject(['<html><body></body></html>'], { nonce: 'abc123' });
     assert.match(html, /<script nonce="abc123">/);
+    // Base64url too — a generator may emit either alphabet, and `=` padding.
+    const urlSafe = await inject(['<html><body></body></html>'], { nonce: 'aB-_0z==' });
+    assert.match(urlSafe, /<script nonce="aB-_0z==">/);
+  });
+
+  test('drops a nonce that is not one rather than writing it into the tag', async () => {
+    // This tag is built by hand, so its attribute value is the one in a rendered document that nothing else
+    // escapes. The value is not attacker-controlled today — it comes from Hono's `secureHeaders()` — but the
+    // framework does not own where it comes from: `secureHeadersNonce` is an ordinary context variable any
+    // middleware can set. A `"` in it would close the attribute and open a script-injection point in every
+    // page. Dropped rather than escaped: a value that is not a nonce is not one, and a payload script the
+    // policy then refuses is the visible failure to have.
+    for (const nonce of ['" onload="alert(1)', 'abc"><script>alert(1)</script>', 'has space', 'weird;value', '<>']) {
+      const html = await inject(['<html><body></body></html>'], { nonce });
+      assert.match(html, /<script>\(self\.__FLIGHT_DATA/, `"${nonce}" must not reach the tag`);
+      assert.equal(countOf(html, 'nonce'), 0, `"${nonce}" was written into the document`);
+    }
   });
 
   test('escapes a payload that would close the script element early', async () => {

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, sep } from 'node:path';
 import { after, describe, test } from 'node:test';
 
 import { scanPageFiles } from '../dist/builder/page-files.js';
@@ -957,10 +957,22 @@ describe('the env-shadow prelude', () => {
 describe('env-shadow-loader', () => {
   const envShadowLoader = createRequire(import.meta.url)('../dist/builder/env-shadow-loader.cjs');
   const PRELUDE = 'const process = { env: {} }; ';
+  const APP_SRC = join(tmpdir(), 'rshono-app', 'src');
 
-  /** The slice of Rspack's loader context this loader reads. `layer` is the layer the *module* is in. */
-  const run = (source, { layer = 'ssr' } = {}) =>
-    envShadowLoader.call({ getOptions: () => ({ prelude: PRELUDE, layer: 'ssr' }), _module: { layer } }, source);
+  /**
+   * The slice of Rspack's loader context this loader reads. `layer` is the layer the *module* is in, and
+   * `resourcePath` decides whether a module counts as the app's own source for the warning below.
+   */
+  const run = (source, { layer = 'ssr', resourcePath = join(APP_SRC, 'component.tsx'), warnings } = {}) =>
+    envShadowLoader.call(
+      {
+        getOptions: () => ({ prelude: PRELUDE, layer: 'ssr', appSrcPrefix: APP_SRC + sep }),
+        _module: { layer },
+        resourcePath,
+        emitWarning: (warning) => warnings?.push(warning.message),
+      },
+      source,
+    );
 
   test('shadows env only in the layer it was configured for', () => {
     const source = 'export const x = process.env.SECRET;';
@@ -969,11 +981,67 @@ describe('env-shadow-loader', () => {
     assert.equal(run(source, { layer: null }), source);
   });
 
-  test('leaves a module that never mentions process.env untouched', () => {
+  test('leaves a module that never mentions process untouched', () => {
     // The fast path: every module in the bundle now reaches this loader, so the common case has to be one
     // string scan and out.
-    const source = 'export const x = 1;';
-    assert.equal(run(source), source);
+    assert.equal(run('export const x = 1;'), 'export const x = 1;');
+    // And a word that merely contains it is not a mention. Being wrong here only costs bytes, but
+    // `child_process` and `preprocess` are common enough to be worth not paying for.
+    for (const source of ['export const x = preprocess(1);', 'export const x = processEnv;', "import cp from 'node:child_process';"]) {
+      assert.equal(run(source), source, `"${source}" must not drag the prelude in`);
+    }
+  });
+
+  test('shadows every shape that reads the env through the process binding, not just the literal process.env', () => {
+    // A gate on the substring `process.env` saw one shape out of six. The prelude replaces the whole
+    // binding, so all of them are covered once it is emitted — `process?.env` above all, which is how env
+    // access is written in code meant to run in a browser *and* on a server, i.e. in a `'use client'`
+    // component. Every miss rendered the real value into the SSR'd HTML while the browser bundle saw the
+    // `PUBLIC_`-only view: a leaked secret, and a hydration mismatch besides.
+    for (const source of [
+      'export const x = process.env.DATABASE_URL;',
+      'const { DATABASE_URL } = process.env;',
+      'export const x = process?.env.DATABASE_URL;',
+      "export const x = process['env'].DATABASE_URL;",
+      'const { env } = process;',
+      'const p = process; export const x = p.env.DATABASE_URL;',
+      "export const x = typeof process !== 'undefined' ? process.env.DATABASE_URL : '';",
+    ]) {
+      assert.equal(run(source), PRELUDE + source, `"${source}" must be shadowed`);
+    }
+  });
+
+  test('warns when the app reads process through the global object, which no binding can shadow', () => {
+    // `globalThis.process` is the real `process` however the module names it, so the prelude cannot reach
+    // it — the read has to be found by a person. Only the app's own source is worth saying it about: a
+    // library feature-detecting `globalThis.process?.env?.NODE_ENV` is doing nothing wrong and has no app
+    // secret to read.
+    for (const source of [
+      'export const x = globalThis.process.env.DATABASE_URL;',
+      'export const x = globalThis?.process?.env?.DATABASE_URL;',
+      "export const x = global['process'].env.DATABASE_URL;",
+      'export const x = self.process.env.DATABASE_URL;',
+    ]) {
+      const warnings = [];
+      assert.equal(run(source, { warnings }), PRELUDE + source, 'the prelude is still emitted');
+      assert.equal(warnings.length, 1, `"${source}" must be reported`);
+      assert.match(warnings[0], /reads `process` through the global object/);
+    }
+
+    const fromLibrary = [];
+    run('export const x = globalThis.process.env.NODE_ENV;', {
+      resourcePath: join(tmpdir(), 'rshono-app', 'node_modules', 'ui', 'index.js'),
+      warnings: fromLibrary,
+    });
+    assert.deepEqual(fromLibrary, [], 'a dependency is not the app author to tell');
+
+    const rsc = [];
+    run('export const x = globalThis.process.env.DATABASE_URL;', { layer: 'rsc', warnings: rsc });
+    assert.deepEqual(rsc, [], 'a server component is meant to read the real env');
+
+    const shadowed = [];
+    run('export const x = process.env.DATABASE_URL;', { warnings: shadowed });
+    assert.deepEqual(shadowed, [], 'the shape the shadow does cover says nothing');
   });
 
   test('inserts the prelude after the whole directive prologue, not after the first directive', () => {

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -423,10 +423,41 @@ describe('ssgFilePath', () => {
   // The shared guard every deploy target relies on: an asset store addressed by key has no
   // `resolve()` to fall back on, so a traversal has to be refused here or not at all.
   test('refuses traversal in a request path, escaped or not', () => {
-    const attempts = ['/../secret', '/docs/../../etc/passwd', '/..', '/docs/..', '/./docs', '/docs/./x', '/%2e%2e/secret', '/..%2f'];
+    const attempts = ['/../secret', '/docs/../../etc/passwd', '/..', '/docs/..', '/./docs', '/docs/./x', '/%2e%2e/secret', '/..%2f', '/..%2F'];
     for (const attempt of attempts) {
       assert.equal(ssgFilePath(attempt, 'html'), null, `${attempt} must not resolve to a file`);
     }
+  });
+
+  // Not a traversal, and pinned so nobody "fixes" it into one: a double-encoded escape decodes to the
+  // literal text `..%2f`, which is one ordinary directory name. The single-encoded forms above are the
+  // ones that decode to a separator, and those are refused.
+  test('treats a double-encoded escape as the literal name it is', () => {
+    assert.equal(ssgFilePath('/..%252f'), '..%2f/index.html');
+  });
+
+  // The guard checks *decoded* segments, so what arrives decoded and what does not is load-bearing. Both
+  // layers below are upstream, and neither is ours to change — hence a test rather than a comment.
+  test('the upstream layers the guard is written against keep their promises', async () => {
+    // 1. The URL parser resolves a percent-encoded dot segment when the Request is built, so `%2e%2e`
+    //    never reaches a handler as a segment at all.
+    for (const encoded of ['%2e%2e', '%2E%2E']) {
+      assert.equal(new URL(`/docs/${encoded}/x`, 'http://example.test').pathname, '/x', `${encoded} must be resolved by the URL parser`);
+    }
+
+    // 2. Hono hands a handler the path with `decodeURI` run over it, which is the form `ssgFilePath`
+    //    stores under — and `decodeURI` leaves the reserved escapes alone, so a `%2F` arrives as an escape
+    //    rather than as a separator and cannot smuggle a second segment past the router. The framework's
+    //    own per-segment `decodeURIComponent` is what then refuses it as a file name (asserted above).
+    const { Hono } = await import('hono');
+    const app = new Hono();
+    const seen = [];
+    app.get('*', (c) => {
+      seen.push(c.req.path);
+      return c.text('ok');
+    });
+    for (const path of ['/docs/caf%C3%A9', '/docs/a%2Fb']) await app.fetch(new Request(`http://example.test${path}`));
+    assert.deepEqual(seen, ['/docs/café', '/docs/a%2Fb'], 'a non-reserved escape arrives decoded; a %2F arrives as itself');
   });
 });
 
@@ -525,13 +556,27 @@ describe('readPrerendered', () => {
     assert.equal(await readPrerendered(tempDir(), '/nope'), null);
   });
 
-  test('refuses to escape the ssg directory, decoded form included', async () => {
-    // `ssgFilePath` above is where the exhaustive path cases live; what this adds is that the
-    // percent-encoded form is decoded *before* the check rather than after it.
-    const dir = tempDir();
-    for (const attempt of ['/../', '/..%2f', '/docs/../../etc']) {
-      assert.equal(await readPrerendered(dir, attempt), null, `traversal attempt "${attempt}" must not resolve`);
+  test('refuses to escape the ssg directory, with the file a traversal would reach actually there', async () => {
+    // The version of this test that shipped first ran its attempts against a *freshly created empty* temp
+    // dir, so `null` proved nothing beyond "no file was there". Here the file a traversal is aiming at
+    // exists and is readable, so the only thing that can refuse it is the guard.
+    const parent = tempDir();
+    const store = join(parent, 'store');
+    mkdirSync(join(parent, 'sibling'), { recursive: true });
+    mkdirSync(store, { recursive: true });
+    writeFileSync(join(parent, 'sibling', 'index.html'), '<!DOCTYPE html><p>outside the store</p>');
+    // The control: the bytes are there, one `..` away from the root, and nothing but the guard is between
+    // them and a response.
+    assert.match(readFileSync(join(store, '..', 'sibling', 'index.html'), 'utf8'), /outside the store/);
+
+    for (const attempt of ['/../sibling', '/../sibling/', '/docs/../../sibling', '/..%2fsibling', '/%2e%2e/sibling']) {
+      assert.equal(await readPrerendered(store, attempt), null, `traversal attempt "${attempt}" must not resolve`);
     }
+
+    // And a page genuinely inside the store still resolves, so the guard is not simply refusing everything.
+    mkdirSync(join(store, 'sibling'), { recursive: true });
+    writeFileSync(join(store, 'sibling', 'index.html'), '<!DOCTYPE html><p>inside</p>');
+    assert.ok(await readPrerendered(store, '/sibling'), 'the same name inside the root is an ordinary page');
   });
 });
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -2,7 +2,7 @@
 // exercises indirectly through one happy path. They import the *built* package, so they double as a
 // check that dist is importable from plain Node.
 import assert from 'node:assert/strict';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, sep } from 'node:path';
@@ -1614,18 +1614,19 @@ describe('parseRenderRequest', () => {
 });
 
 describe('the security-middleware build warning', () => {
-  /** The minimal app somewhere disposable, plus whatever `src/server.ts` the case wants. */
+  /**
+   * The minimal app somewhere disposable, plus whatever `src/server.ts` the case wants.
+   *
+   * No `node_modules`: `createConfigs` builds config objects and scans `src/`, and resolves packages from
+   * the *framework's* tree rather than the app's, so nothing here reads one. It used to borrow the
+   * fixture's through a junction, which was both unnecessary and a Windows reparse point for no reason.
+   */
   function appWithServer(serverSource) {
     const dir = mkdtempSync(join(tmpdir(), 'rshono-warn-'));
-    symlinkSync(join(MINIMAL_APP_DIR, 'node_modules'), join(dir, 'node_modules'), 'junction');
     cpSync(join(MINIMAL_APP_DIR, 'package.json'), join(dir, 'package.json'));
     cpSync(join(MINIMAL_APP_DIR, 'src'), join(dir, 'src'), { recursive: true });
     if (serverSource !== null) writeFileSync(join(dir, 'src', 'server.ts'), serverSource);
-    after(() => {
-      // The link, not what it points at: `node_modules` is the fixture's, borrowed rather than copied.
-      unlinkSync(join(dir, 'node_modules'));
-      rmSync(dir, { recursive: true, force: true });
-    });
+    after(() => rmSync(dir, { recursive: true, force: true }));
     return dir;
   }
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -20,6 +20,7 @@ import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
 import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/runtime/control.js';
 import { beginPageRender, RequestContext } from '../dist/runtime/context.js';
 import { walkHotUpdates } from '../dist/runtime/hot-update.js';
+import { validateRoutesModule, validateServerApp } from '../dist/runtime/validate-entries.js';
 import { MINIMAL_APP_DIR } from './helpers.mjs';
 
 const tempDirs = [];
@@ -1107,5 +1108,106 @@ describe('walkHotUpdates', () => {
     target = 'c';
     assert.equal(await done, null);
     assert.equal(state.hash, 'c');
+  });
+});
+
+describe('validateRoutesModule', () => {
+  // The app's own `src/routes.ts`, checked before anything is built on it. Everything below either
+  // crashed somewhere unrelated (`nN is not iterable`, from a minified bundle) or did nothing at all.
+  const page = { path: '/', component: () => Promise.resolve({ default: () => null }) };
+  const endpoint = { type: 'endpoint', path: '/api/x', server: () => Promise.resolve({ handler: () => null }) };
+  const rejects = (exported, expected) => assert.throws(() => validateRoutesModule(exported), expected);
+
+  test('accepts both shapes the docs present, so leaving off defineRoutes is not a trap', () => {
+    assert.deepEqual(validateRoutesModule([page]), { routes: [page] });
+    const config = { routes: [page], notFound: { component: page.component } };
+    assert.equal(validateRoutesModule(config), config, 'a config is returned as it came');
+  });
+
+  test('names src/routes.ts when the export is not a route table at all', () => {
+    for (const exported of [undefined, null, 42, {}, { routes: 'nope' }]) {
+      rejects(exported, /\[rshono\] src\/routes\.ts must export `routes`/);
+    }
+  });
+
+  test('names the entry that is wrong, by position and by path', () => {
+    rejects([page, null], /routes\[1\] is null, not a route object/);
+    rejects([page, { component: page.component }], /routes\[1\] needs a `path` starting with "\/"/);
+    rejects([{ path: 'docs', component: page.component }], /routes\[0\] \("docs"\) needs a `path` starting with "\/"/);
+    rejects([{ path: '/x' }], /routes\[0\] \("\/x"\) needs `component`/);
+    rejects([{ type: 'page', path: '/x', component: page.component }], /the only `type` is 'endpoint'/);
+    rejects([{ type: 'endpoint', path: '/api/x' }], /is an endpoint, so it needs `server`/);
+  });
+
+  // Excess-property checking against a union accepts any key present in *some* member, so these
+  // type-check today and are then silently ignored — which looks exactly like a feature not working.
+  test('refuses a key that belongs to the other kind of route', () => {
+    rejects([{ ...endpoint, render: 'static' }], /has `render`, which only a page route has/);
+    rejects([{ ...endpoint, staticPaths: async () => [] }], /has `staticPaths`, which only a page route has/);
+    rejects([{ ...page, method: 'get' }], /has `method`, which only an endpoint route has/);
+    rejects([{ ...page, server: endpoint.server }], /has `server`, which only an endpoint route has/);
+  });
+
+  test('refuses a staticPaths the build would never call', () => {
+    rejects([{ ...page, path: '/docs/:slug', staticPaths: async () => [{ slug: 'a' }] }], /is not `render: 'static'`/);
+    rejects([{ ...page, render: 'static', staticPaths: 'nope' }], /`staticPaths` that is not a function/);
+    rejects([{ ...page, render: 'lazy' }], /has render "lazy" — it is 'static' or 'dynamic'/);
+  });
+
+  test("refuses a method the router cannot match, and points 'head' at 'get'", () => {
+    rejects([{ ...endpoint, method: 'HEAD' }], /has method "HEAD", which is not one of get, post/);
+    rejects([{ ...endpoint, method: 'head' }], /A HEAD is dispatched as a GET, so use 'get'/);
+  });
+
+  // The one that built cleanly, exited 0 and said nothing: Hono matches in registration order.
+  test('refuses a route every method of which the table already answers', () => {
+    rejects(
+      [page, { ...page, component: page.component }],
+      /routes\[1\] \("\/"\) would never run — routes\[0\] \("\/"\) already answers GET, POST \//,
+    );
+    rejects([endpoint, { ...endpoint, method: 'get' }], /already answers GET \/api\/x/, 'an `all` endpoint claims every method');
+    rejects([{ ...endpoint, path: '/' }, page], /already answers GET, POST \//, 'an endpoint shadows a page at the same path too');
+  });
+
+  test('leaves a route that still answers something alone', () => {
+    for (const table of [
+      // One path split across two methods — an ordinary thing to write.
+      [
+        { ...endpoint, method: 'get' },
+        { ...endpoint, method: 'post' },
+        { ...page, path: '/other' },
+      ],
+      // A catch-all behind a route claiming one method of the path: it still answers PUT, DELETE, …
+      [{ ...endpoint, method: 'post' }, endpoint],
+      // Overlapping *patterns* are the router's business, and specific-before-generic is the point.
+      [
+        { ...page, path: '/docs/getting-started' },
+        { ...page, path: '/docs/:slug' },
+      ],
+    ]) {
+      assert.deepEqual(validateRoutesModule(table).routes, table);
+    }
+  });
+
+  test('checks the two framework-owned pages as well', () => {
+    rejects({ routes: [page], notFound: {} }, /`notFound` must be a page/);
+    rejects({ routes: [page], error: () => null }, /`error` must be a page/);
+  });
+});
+
+describe('validateServerApp', () => {
+  test('takes the Hono app, or nothing where the app has no src/server.ts', () => {
+    // What the empty fallback module the alias resolves to default-exports.
+    assert.equal(validateServerApp({ default: null }), null);
+    assert.equal(validateServerApp({}), null);
+    assert.equal(validateServerApp(null), null);
+    const app = { fetch: () => null, routes: [] };
+    assert.equal(validateServerApp({ default: app }), app);
+  });
+
+  test('names src/server.ts rather than letting Hono throw from inside app.route()', () => {
+    for (const value of [{ notAHono: true }, 'nope', 42, { fetch: () => null }]) {
+      assert.throws(() => validateServerApp({ default: value }), /\[rshono\] src\/server\.ts must `export default` a Hono app/);
+    }
   });
 });

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -1195,6 +1195,7 @@ describe('env-shadow-loader', () => {
       'export const x = globalThis.process.env.DATABASE_URL;',
       'export const x = globalThis?.process?.env?.DATABASE_URL;',
       "export const x = global['process'].env.DATABASE_URL;",
+      "export const x = globalThis?.['process']?.env?.DATABASE_URL;",
       'export const x = self.process.env.DATABASE_URL;',
     ]) {
       const warnings = [];

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -6,20 +6,21 @@ import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unli
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, sep } from 'node:path';
-import { after, describe, test } from 'node:test';
+import { after, before, describe, test } from 'node:test';
 
 import { scanPageFiles } from '../dist/builder/page-files.js';
 import { checkReactVersions } from '../dist/builder/react-versions.js';
 import { createConfigs } from '../dist/builder/rspack-config.js';
 import { DEPLOY_TARGETS, deployHintFor, NODE_PRESET, resolveDeployPreset } from '../dist/deploy/presets.js';
 import { appendVary, etagMatches } from '../dist/server/headers.js';
+import { loadConfig } from '../dist/server/load-config.js';
 import { parsePort, resolveServerConfig } from '../dist/server/server-config.js';
 import { createPageCache, ssgAssetPath, ssgFilePath } from '../dist/server/prerendered.js';
 import { prerenderStaticRoutes, readPrerendered, resolveSiteOrigin } from '../dist/server/ssg.js';
 import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
 import { asksForRsc, createRscRequest, isActionRequest, parseRenderRequest, wantsRsc } from '../dist/runtime/request.js';
 import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/runtime/control.js';
-import { beginPageRender, RequestContext } from '../dist/runtime/context.js';
+import { beginPageRender, onServerError, publicUrl, reportServerError, RequestContext } from '../dist/runtime/context.js';
 import { walkHotUpdates } from '../dist/runtime/hot-update.js';
 import { validateRoutesModule, validateServerApp } from '../dist/runtime/validate-entries.js';
 import { MINIMAL_APP_DIR, TESTBED_DIR } from './helpers.mjs';
@@ -303,6 +304,257 @@ describe('injectFlightPayload', () => {
 // Two fields, because only two things here are decided by the build. The CSRF check, the CSP and the
 // body cap used to live alongside them and are now Hono middleware an app registers in src/server.ts
 // — see prod-config.test.mjs, which exercises them over HTTP rather than through a resolver.
+// The single funnel every caught server-side error goes through. `prod.test.mjs` covers the happy path over
+// HTTP; these are the parts an app only meets when something else has already gone wrong.
+describe('reportServerError', () => {
+  const hono = { req: { raw: new Request('http://example.test/boom') } };
+  const report = (error, source = 'request') => reportServerError(error, { source, hono, message: '[rshono] test:' });
+
+  /** Runs `body` with `console.error` collected rather than printed — every report writes one. */
+  function withStderr(body) {
+    const lines = [];
+    const original = console.error;
+    console.error = (...args) => lines.push(args.map(String).join(' '));
+    try {
+      body(lines);
+    } finally {
+      console.error = original;
+    }
+    return lines;
+  }
+
+  // Registered handlers are module state with no way to unregister, so every test sets its own and the
+  // last one leaves a no-op behind.
+  after(() => onServerError(() => {}));
+
+  test('hands the handler the source, the request and the Hono context, and still writes to stderr', () => {
+    const seen = [];
+    onServerError((error, context) => seen.push({ error, ...context }));
+    const lines = withStderr(() => report(new Error('boom'), 'action'));
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].source, 'action');
+    assert.equal(seen[0].error.message, 'boom');
+    assert.equal(seen[0].request.url, 'http://example.test/boom', 'the request is derived from the context');
+    assert.equal(seen[0].hono, hono);
+    assert.equal(typeof seen[0].waitUntil, 'function');
+    assert.match(lines.join('\n'), /\[rshono\] test:/, 'a handler must not replace the stderr log');
+  });
+
+  test('reports one fault once, however many stages catch it', () => {
+    const seen = [];
+    onServerError((_error, { source }) => seen.push(source));
+    withStderr(() => {
+      const error = new Error('one fault');
+      // What a thrown server action does: reported where it is known to be an action, then re-thrown, which
+      // lands it in the top-level handler as well. Two sources for one fault is worse than only the outer.
+      report(error, 'action');
+      report(error, 'request');
+    });
+    assert.deepEqual(seen, ['action'], 'the first stage to recognise it wins — it is the one that knows what it was');
+  });
+
+  test('reports a primitive throw wherever it is caught, having nothing to track it by', () => {
+    const seen = [];
+    onServerError((_error, { source }) => seen.push(source));
+    withStderr(() => {
+      report('a string', 'render');
+      report('a string', 'request');
+    });
+    assert.deepEqual(seen, ['render', 'request'], 'a primitive cannot go in a WeakSet, so it is reported twice');
+  });
+
+  test('a handler that throws is caught and logged, and does not fail the request', () => {
+    onServerError(() => {
+      throw new Error('the tracker is down');
+    });
+    const lines = withStderr(() => {
+      assert.doesNotThrow(() => report(new Error('boom')), 'reporting can never be what fails a request');
+    });
+    assert.match(lines.join('\n'), /the onServerError handler threw/);
+    assert.match(lines.join('\n'), /the tracker is down/, 'and the handler’s own error is not swallowed');
+  });
+
+  test('registering again replaces the previous handler', () => {
+    const calls = [];
+    onServerError(() => calls.push('first'));
+    onServerError(() => calls.push('second'));
+    withStderr(() => report(new Error('boom')));
+    assert.deepEqual(calls, ['second'], 'one funnel, not a growing list');
+  });
+
+  test('waitUntil is a no-op where the platform has no execution context, and swallows a rejection', async () => {
+    // `c.executionCtx` *throws* rather than answering undefined, so a handler reaching for it itself would
+    // have its report swallowed by the guard above — on exactly the platforms where nothing needed holding
+    // open. And an unhandled rejection from a report must not be what ends the process.
+    const rejections = [];
+    const onRejection = (error) => rejections.push(error);
+    process.on('unhandledRejection', onRejection);
+    // Captured across the await rather than with `withStderr`: the rejection is logged a tick after the
+    // report returns, which is exactly the window that helper closes.
+    const lines = [];
+    const original = console.error;
+    console.error = (...args) => lines.push(args.map(String).join(' '));
+    try {
+      onServerError((_error, { waitUntil }) => {
+        assert.doesNotThrow(() => waitUntil(Promise.resolve('sent')));
+        waitUntil(Promise.reject(new Error('the tracker refused it')));
+      });
+      report(new Error('boom'));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.deepEqual(rejections, [], 'a failed report must not surface as an unhandled rejection');
+      assert.match(lines.join('\n'), /waitUntil rejected/);
+      assert.match(lines.join('\n'), /the tracker refused it/);
+    } finally {
+      console.error = original;
+      process.off('unhandledRejection', onRejection);
+    }
+  });
+});
+
+// Every branch here ends in a message someone reads while a build is failing, and only the happy path of
+// `--config` was covered — indirectly, by `prod-config.test.mjs` building with a fixture config.
+describe('loadConfig', () => {
+  test('returns an empty config where the project has none', async () => {
+    assert.deepEqual(await loadConfig(tempDir()), {}, 'no config file is not an error — every field has a default');
+  });
+
+  test('finds rshono.config.{ts,js,mjs} at the root, in that order', async () => {
+    for (const [name, marker] of [
+      ['rshono.config.ts', 'ts'],
+      ['rshono.config.js', 'js'],
+      ['rshono.config.mjs', 'mjs'],
+    ]) {
+      const dir = tempDir();
+      writeFileSync(join(dir, name), `export default { siteUrl: 'https://${marker}.example' };\n`);
+      assert.equal((await loadConfig(dir)).siteUrl, `https://${marker}.example`, `${name} must be found`);
+    }
+
+    // Precedence, so a leftover file cannot quietly win: .ts first.
+    const dir = tempDir();
+    writeFileSync(join(dir, 'rshono.config.mjs'), "export default { siteUrl: 'https://mjs.example' };\n");
+    writeFileSync(join(dir, 'rshono.config.ts'), "export default { siteUrl: 'https://ts.example' };\n");
+    assert.equal((await loadConfig(dir)).siteUrl, 'https://ts.example');
+  });
+
+  test('names an explicit --config that is not there, rather than failing later', async () => {
+    const missing = join(tempDir(), 'nope.config.mjs');
+    await assert.rejects(loadConfig(tempDir(), missing), /\[rshono\] config file not found: /);
+  });
+
+  test('resolves a relative --config against the working directory', async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, 'custom.config.mjs'), "export default { siteUrl: 'https://custom.example' };\n");
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      assert.equal((await loadConfig(tempDir(), 'custom.config.mjs')).siteUrl, 'https://custom.example');
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  test('says a config with no default export is missing one', async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, 'rshono.config.mjs'), "export const config = { siteUrl: 'https://x.example' };\n");
+    await assert.rejects(loadConfig(dir), /must `export default` a config object/);
+  });
+
+  // The bespoke branch: Node strips types itself, and the one thing it will not do is rewrite a `.js`
+  // specifier to the `.ts` file beside it. Without the hint this surfaces as a raw ERR_MODULE_NOT_FOUND
+  // naming a path that does exist — as a .ts file.
+  test("explains a .ts config importing a sibling by its '.js' specifier", async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, 'shared.ts'), 'export const siteUrl = "https://shared.example";\n');
+    writeFileSync(join(dir, 'rshono.config.ts'), "import { siteUrl } from './shared.js';\nexport default { siteUrl };\n");
+    await assert.rejects(loadConfig(dir), (error) => {
+      assert.match(error.message, /imports a module Node could not resolve/);
+      assert.match(error.message, /does not rewrite a \.js specifier/);
+      assert.equal(error.cause?.code, 'ERR_MODULE_NOT_FOUND', 'the original is kept as the cause');
+      return true;
+    });
+
+    // And the same import by its real extension loads, so the advice is advice that works. In a directory
+    // of its own: Node's module registry keeps the failed load above under its URL, so rewriting the file
+    // in place would re-throw it.
+    const fixed = tempDir();
+    writeFileSync(join(fixed, 'shared.ts'), 'export const siteUrl = "https://shared.example";\n');
+    writeFileSync(join(fixed, 'rshono.config.ts'), "import { siteUrl } from './shared.ts';\nexport default { siteUrl };\n");
+    assert.equal((await loadConfig(fixed)).siteUrl, 'https://shared.example');
+  });
+
+  test('lets any other import failure through as itself', async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, 'rshono.config.mjs'), 'throw new Error("config blew up");\n');
+    await assert.rejects(loadConfig(dir), /config blew up/, 'a config that throws must not be dressed up as a resolution hint');
+  });
+});
+
+// The browser-facing URL, which is what `csrf()` and every absolute link the app builds depend on. Reached
+// only through `prod-config.test.mjs`'s `csrf()` assertions until now, so the pieces below — a forwarded
+// chain, a forwarded host with no port, a host that is not one — were covered end to end at best and not at
+// all in the cases the e2e app does not send.
+describe('publicUrl', () => {
+  /** The two members `publicUrl` reads, and nothing else, so the test says what it depends on. */
+  const request = (url, headers = {}) => ({ req: { url, header: (name) => headers[name.toLowerCase()] } });
+
+  test('ignores the forwarded headers when trustProxy is off', () => {
+    const url = publicUrl(request('http://127.0.0.1:3000/a?b=1', { 'x-forwarded-host': 'evil.example', 'x-forwarded-proto': 'https' }));
+    assert.equal(url.href, 'http://127.0.0.1:3000/a?b=1', 'the default must be the address the server was reached on');
+  });
+
+  describe('with trustProxy on', () => {
+    // The flag is a module-level const read from the `DefinePlugin` global when the module is first
+    // evaluated, so the only way to reach the other branch is a fresh module instance with the global
+    // already set. The query string is what makes the import fresh.
+    let trusted;
+    before(async () => {
+      globalThis.__RSHONO_CONFIG__ = { trustProxy: true, isDev: false };
+      trusted = (await import('../dist/runtime/context.js?trustProxy=1')).publicUrl;
+    });
+    after(() => {
+      delete globalThis.__RSHONO_CONFIG__;
+    });
+
+    test('takes the host and scheme the browser used, and drops the internal port', () => {
+      // The port is the subtle one: assigning `url.host` would keep :3000 when the new value has none,
+      // which is why the implementation parses instead. Asserted end to end once; never in isolation.
+      const url = trusted(request('http://127.0.0.1:3000/a?b=1', { 'x-forwarded-host': 'example.com', 'x-forwarded-proto': 'https' }));
+      assert.equal(url.href, 'https://example.com/a?b=1');
+    });
+
+    test('keeps a port the forwarded host names', () => {
+      const url = trusted(request('http://127.0.0.1:3000/', { 'x-forwarded-host': 'example.com:8443', 'x-forwarded-proto': 'https' }));
+      assert.equal(url.href, 'https://example.com:8443/');
+    });
+
+    test('honours the first hop of a proxy chain, which is the client-facing one', () => {
+      const url = trusted(
+        request('http://127.0.0.1:3000/', { 'x-forwarded-host': 'example.com, inner.local:8080', 'x-forwarded-proto': 'https, http' }),
+      );
+      assert.equal(url.href, 'https://example.com/', 'a chain appends, so the browser-facing value is the first entry');
+    });
+
+    test('leaves the URL alone where a header is not usable', () => {
+      const internal = 'http://127.0.0.1:3000/a';
+      // A host no URL can hold, an empty value, and a scheme a browser could not have requested. Each
+      // leaves that half of the URL as it was rather than throwing or guessing.
+      assert.equal(trusted(request(internal, { 'x-forwarded-host': 'a b' })).href, internal, 'an unparseable host');
+      assert.equal(trusted(request(internal, { 'x-forwarded-host': '  ' })).href, internal, 'a blank host');
+      assert.equal(trusted(request(internal, { 'x-forwarded-host': ', example.com' })).href, internal, 'a blank first hop');
+      assert.equal(trusted(request(internal, { 'x-forwarded-proto': 'ftp' })).href, internal, 'a scheme that is not http(s)');
+      assert.equal(trusted(request(internal, { 'x-forwarded-proto': 'HTTPS' })).href, internal, 'and it is compared case-sensitively');
+    });
+
+    test('returns a fresh URL each call, so a caller mutating one cannot affect the next', () => {
+      const c = request('http://127.0.0.1:3000/', { 'x-forwarded-host': 'example.com' });
+      const first = trusted(c);
+      first.pathname = '/mutated';
+      assert.equal(trusted(c).pathname, '/');
+    });
+  });
+});
+
 describe('resolveServerConfig', () => {
   test('applies the documented defaults', () => {
     const config = resolveServerConfig({}, { isDev: false });

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -563,12 +563,17 @@ describe('prerenderStaticRoutes', () => {
       },
     });
 
-    assert.deepEqual(result.written, ['/about', '/docs/a', '/docs/b']);
+    assert.deepEqual(result.written, ['/about', '/docs/a', '/docs/b'], 'reported in route order, whatever order they rendered in');
     assert.deepEqual(
-      requested,
-      ['document /about', 'flight /about', 'document /docs/a', 'flight /docs/a', 'document /docs/b', 'flight /docs/b'],
+      requested.toSorted(),
+      ['document /about', 'document /docs/a', 'document /docs/b', 'flight /about', 'flight /docs/a', 'flight /docs/b'],
       'each path is rendered as a document and as a flight payload; a dynamic route is never prerendered',
     );
+    // Sorted above because paths render concurrently. Within a path the order is still fixed: the flight
+    // payload is only asked for once the document has come back 200.
+    for (const path of ['/about', '/docs/a', '/docs/b']) {
+      assert.ok(requested.indexOf(`document ${path}`) < requested.indexOf(`flight ${path}`), `${path}: document before flight`);
+    }
     const decode = (page) => new TextDecoder().decode(page.body);
     assert.equal(decode(await readPrerendered(ssgDir, '/docs/a')), '<!DOCTYPE html><p>ok</p>');
     assert.equal(decode(await readPrerendered(ssgDir, '/docs/a', 'flight')), '0:{"root":"flight"}');
@@ -584,6 +589,68 @@ describe('prerenderStaticRoutes', () => {
       'docs/b/index.html',
       'docs/b/index.rsc',
     ]);
+  });
+
+  test('renders a path once however many times staticPaths returns it', async () => {
+    const requested = [];
+    const warnings = [];
+    const warn = console.warn;
+    console.warn = (message) => warnings.push(String(message));
+    let result;
+    try {
+      result = await prerenderStaticRoutes({
+        ssgDir: tempDir(),
+        routes: [
+          {
+            path: '/docs/:slug',
+            render: 'static',
+            component: async () => ({ default: () => null }),
+            staticPaths: async () => [{ slug: 'a' }, { slug: 'b' }, { slug: 'a' }],
+          },
+        ],
+        fetch: (request) => {
+          requested.push(new URL(request.url).pathname);
+          return okResponse(request);
+        },
+      });
+    } finally {
+      console.warn = warn;
+    }
+
+    assert.deepEqual(result.written, ['/docs/a', '/docs/b']);
+    assert.equal(requested.filter((path) => path === '/docs/a').length, 2, 'one document and one flight payload, not two of each');
+    assert.match(warnings.join('\n'), /repeated 1 path/, 'and the app is told, since a repeated entry is usually a bug in its query');
+  });
+
+  test('renders paths concurrently, up to a bound', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const slugs = Array.from({ length: 20 }, (_, index) => `p${index}`);
+    const result = await prerenderStaticRoutes({
+      ssgDir: tempDir(),
+      routes: [
+        {
+          path: '/docs/:slug',
+          render: 'static',
+          component: async () => ({ default: () => null }),
+          staticPaths: async () => slugs.map((slug) => ({ slug })),
+        },
+      ],
+      fetch: async (request) => {
+        peak = Math.max(peak, ++inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight--;
+        return okResponse(request);
+      },
+    });
+
+    assert.deepEqual(
+      result.written,
+      slugs.map((slug) => `/docs/${slug}`),
+      'reported in staticPaths order, whatever order they finished in',
+    );
+    assert.ok(peak > 1, "rendered one at a time, a few hundred paths pay every page's latency in series");
+    assert.ok(peak <= 8, `and rendered all at once, a build points the whole site at the app's database (peak ${peak})`);
   });
 
   test('renders against siteUrl, so absolute URLs in the output are the deployed ones', async () => {
@@ -694,8 +761,8 @@ describe('prerenderStaticRoutes', () => {
 
     assert.deepEqual(result.written, ['/docs/caf%C3%A9', '/docs/a%20b']);
     assert.deepEqual(
-      requested,
-      ['/docs/caf%C3%A9', '/docs/caf%C3%A9', '/docs/a%20b', '/docs/a%20b'],
+      requested.toSorted(),
+      ['/docs/a%20b', '/docs/a%20b', '/docs/caf%C3%A9', '/docs/caf%C3%A9'],
       'the page is fetched at the URL a browser would use, once per representation',
     );
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -14,7 +14,7 @@ import { createConfigs } from '../dist/builder/rspack-config.js';
 import { DEPLOY_TARGETS, deployHintFor, NODE_PRESET, resolveDeployPreset } from '../dist/deploy/presets.js';
 import { appendVary, etagMatches } from '../dist/server/headers.js';
 import { resolveServerConfig } from '../dist/server/server-config.js';
-import { createPageCache, prerenderedRelPath, ssgFilePath } from '../dist/server/prerendered.js';
+import { createPageCache, ssgAssetPath, ssgFilePath } from '../dist/server/prerendered.js';
 import { prerenderStaticRoutes, readPrerendered, resolveSiteOrigin } from '../dist/server/ssg.js';
 import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
 import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/runtime/control.js';
@@ -255,6 +255,9 @@ describe('etagMatches', () => {
 });
 
 describe('ssgFilePath', () => {
+  // The one mapping from a path to the file holding its page — the build's and every deploy target's,
+  // because two of them is how a page gets written where no request will ever look for it.
+  //
   // Always '/'-separated, on every host: the same string addresses a file (`resolve()` takes forward
   // slashes on Windows) and a key in an asset store, where a backslash is simply the wrong character.
   test('maps a concrete route path to its index.html', () => {
@@ -268,24 +271,45 @@ describe('ssgFilePath', () => {
     assert.equal(ssgFilePath('/docs', 'flight'), 'docs/index.rsc');
   });
 
-  test('refuses patterns that are not a single concrete path', () => {
-    assert.equal(ssgFilePath('/docs/:slug'), null);
-    assert.equal(ssgFilePath('/files/*'), null);
-  });
-});
-
-describe('prerenderedRelPath', () => {
-  // The shared guard every deploy target relies on: an asset store addressed by key has no
-  // `resolve()` to fall back on, so a traversal has to be refused here or not at all.
-  test('refuses traversal in a request path', () => {
-    for (const attempt of ['/../secret', '/docs/../../etc/passwd', '/..', '/docs/..', '/./docs', '/docs/./x']) {
-      assert.equal(prerenderedRelPath(attempt, 'html'), null, `${attempt} must not resolve to a file`);
+  // The blocker this replaced: the build interpolated `staticPaths` values with `encodeURIComponent`,
+  // while Hono hands a handler `c.req.path` with `decodeURI` already run over any path holding a `%`.
+  // Every non-ASCII slug was therefore built and then never served.
+  test('resolves the encoded and the decoded form of a path to the same file', () => {
+    for (const [encoded, decoded] of [
+      ['/docs/caf%C3%A9', '/docs/café'],
+      ['/docs/a%20b', '/docs/a b'],
+      ['/%C3%BC', '/ü'],
+      ['/docs/%E6%97%A5%E6%9C%AC', '/docs/日本'],
+    ]) {
+      assert.equal(ssgFilePath(encoded), `${decoded.slice(1)}/index.html`, `${encoded} must resolve decoded`);
+      assert.equal(ssgFilePath(decoded), ssgFilePath(encoded), `${decoded} and ${encoded} are one page`);
     }
   });
 
-  test('passes an ordinary path through to its file', () => {
-    assert.equal(prerenderedRelPath('/docs/getting-started', 'html'), 'docs/getting-started/index.html');
-    assert.equal(prerenderedRelPath('/', 'flight'), 'index.rsc');
+  test('refuses a segment no portable file name can hold', () => {
+    // The first two are route patterns rather than paths; the rest are characters Windows refuses, or a
+    // `%2F` that would otherwise smuggle a second segment into one param value.
+    for (const path of ['/docs/:slug', '/files/*', '/docs/a%2Fb', '/docs/a%5Cb', '/docs/a?b', '/docs/a|b', '/docs//x']) {
+      assert.equal(ssgFilePath(path), null, `${path} must not resolve to a file`);
+    }
+  });
+
+  // The shared guard every deploy target relies on: an asset store addressed by key has no
+  // `resolve()` to fall back on, so a traversal has to be refused here or not at all.
+  test('refuses traversal in a request path, escaped or not', () => {
+    const attempts = ['/../secret', '/docs/../../etc/passwd', '/..', '/docs/..', '/./docs', '/docs/./x', '/%2e%2e/secret', '/..%2f'];
+    for (const attempt of attempts) {
+      assert.equal(ssgFilePath(attempt, 'html'), null, `${attempt} must not resolve to a file`);
+    }
+  });
+});
+
+describe('ssgAssetPath', () => {
+  // Workers reads the same tree through a URL, so the key has to survive being put into one.
+  test('escapes each segment of a store key, and only the segments', () => {
+    assert.equal(ssgAssetPath('docs/café/index.html'), 'docs/caf%C3%A9/index.html');
+    assert.equal(ssgAssetPath('docs/a b/index.rsc'), 'docs/a%20b/index.rsc');
+    assert.equal(ssgAssetPath('docs/a#b/index.html'), 'docs/a%23b/index.html', 'a # would otherwise start a fragment');
   });
 });
 
@@ -342,7 +366,7 @@ describe('readPrerendered', () => {
   });
 
   test('refuses to escape the ssg directory, decoded form included', async () => {
-    // `prerenderedRelPath` above is where the exhaustive path cases live; what this adds is that the
+    // `ssgFilePath` above is where the exhaustive path cases live; what this adds is that the
     // percent-encoded form is decoded *before* the check rather than after it.
     const dir = tempDir();
     for (const attempt of ['/../', '/..%2f', '/docs/../../etc']) {
@@ -459,16 +483,19 @@ describe('prerenderStaticRoutes', () => {
     }
   });
 
-  test('percent-encodes a param value so it stays one path segment', async () => {
+  // The round trip, not `interpolatePath` in isolation — testing the halves separately is exactly what let
+  // a page be built under a name no request ever resolves to.
+  test('a param value needing percent-encoding is served back for the path the browser asks for', async () => {
+    const ssgDir = tempDir();
     const requested = [];
-    await prerenderStaticRoutes({
-      ssgDir: tempDir(),
+    const result = await prerenderStaticRoutes({
+      ssgDir,
       routes: [
         {
           path: '/docs/:slug',
           render: 'static',
           component: async () => ({ default: () => null }),
-          staticPaths: async () => [{ slug: 'a b/c' }],
+          staticPaths: async () => [{ slug: 'café' }, { slug: 'a b' }],
         },
       ],
       fetch: (request) => {
@@ -476,7 +503,40 @@ describe('prerenderStaticRoutes', () => {
         return okResponse(request);
       },
     });
-    assert.deepEqual(requested, ['/docs/a%20b%2Fc', '/docs/a%20b%2Fc'], 'once per representation');
+
+    assert.deepEqual(result.written, ['/docs/caf%C3%A9', '/docs/a%20b']);
+    assert.deepEqual(
+      requested,
+      ['/docs/caf%C3%A9', '/docs/caf%C3%A9', '/docs/a%20b', '/docs/a%20b'],
+      'the page is fetched at the URL a browser would use, once per representation',
+    );
+
+    // …and read back at `c.req.path`, which is what Hono hands the handler: `decodeURI` has already run.
+    for (const requestPath of ['/docs/café', '/docs/a b']) {
+      assert.ok(await readPrerendered(ssgDir, requestPath), `${requestPath} must be served from the build`);
+      assert.ok(await readPrerendered(ssgDir, requestPath, 'flight'), `${requestPath} must soft-navigate from the build`);
+    }
+  });
+
+  test('fails the build for a value it cannot store as one file, rather than writing a page nothing serves', async () => {
+    for (const slug of ['a b/c', 'a:b', '..']) {
+      await assert.rejects(
+        prerenderStaticRoutes({
+          ssgDir: tempDir(),
+          routes: [
+            {
+              path: '/docs/:slug',
+              render: 'static',
+              component: async () => ({ default: () => null }),
+              staticPaths: async () => [{ slug }],
+            },
+          ],
+          fetch: okResponse,
+        }),
+        /Cannot prerender .* for route "\/docs\/:slug"/,
+        `"${slug}" should be rejected`,
+      );
+    }
   });
 });
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -83,6 +83,40 @@ describe('injectFlightPayload', () => {
     });
   }
 
+  // The five splits above all land in one batch: they are enqueued synchronously, so the boundary macrotask
+  // has not run between them. This one puts a real macrotask between the halves, which is the only shape
+  // `emitBatch` can miss — it tests the joined batch, and a tail is what carries the miss across batches.
+  // React does not produce it (its final flush is one synchronous run), but this injector exists precisely
+  // because `rsc-html-stream` made a narrower version of that same assumption, so it is guarded rather than
+  // asserted about React.
+  test('holds back a document trailer split across two batches', async () => {
+    /** One chunk per batch: the wait is long enough that the injector's boundary has fired in between. */
+    const batchedStreamOf = (chunks) => {
+      let next = 0;
+      return new ReadableStream({
+        async pull(controller) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          if (next >= chunks.length) controller.close();
+          else controller.enqueue(encoder.encode(chunks[next++]));
+        },
+      });
+    };
+
+    const html = await readAll(
+      batchedStreamOf(['<html><body><p>hi</p></bo', 'dy></html>']).pipeThrough(injectFlightPayload(streamOf(['0:"hi"\n']))),
+    );
+    assert.equal(countOf(html, '</body></html>'), 1, 'exactly one trailer, however the batches fell');
+    assert.ok(html.indexOf('__FLIGHT_DATA') < html.indexOf('</body></html>'), 'the script must not land inside the trailer');
+    assert.match(html, /<script>\(self\.__FLIGHT_DATA\|\|=\[\]\)\.push\("0:\\"hi\\"\\n"\)<\/script><\/body><\/html>$/);
+
+    // The other half of holding a tail back: one that never completes still has to come back out. It comes
+    // out *after* the payload scripts, which is deliberate — releasing it as soon as a script wants to go out
+    // is exactly the bug above, since the next batch may be the rest of the trailer. Only a truncated
+    // document can reach this, it is 13 bytes at most, and they stay inside `<body>`.
+    const stump = await readAll(batchedStreamOf(['<html><body>a</bod']).pipeThrough(injectFlightPayload(streamOf(['0:"hi"\n']))));
+    assert.match(stump, /^<html><body>a<script>.*<\/script><\/bod<\/body><\/html>$/, 'a tail that was not a trailer is not lost');
+  });
+
   test('puts the payload script inside the body, before the trailer', async () => {
     const html = await inject(['<html><body><p>hi</p></body></html>']);
     assert.ok(html.indexOf('__FLIGHT_DATA') < html.indexOf('</body></html>'), 'the script must not land after </body>');

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -13,7 +13,7 @@ import { checkReactVersions } from '../dist/builder/react-versions.js';
 import { createConfigs } from '../dist/builder/rspack-config.js';
 import { DEPLOY_TARGETS, deployHintFor, NODE_PRESET, resolveDeployPreset } from '../dist/deploy/presets.js';
 import { appendVary, etagMatches } from '../dist/server/headers.js';
-import { resolveServerConfig } from '../dist/server/server-config.js';
+import { parsePort, resolveServerConfig } from '../dist/server/server-config.js';
 import { createPageCache, ssgAssetPath, ssgFilePath } from '../dist/server/prerendered.js';
 import { prerenderStaticRoutes, readPrerendered, resolveSiteOrigin } from '../dist/server/ssg.js';
 import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
@@ -234,6 +234,33 @@ describe('resolveServerConfig', () => {
     const config = resolveServerConfig({ trustProxy: false }, { isDev: true });
     assert.equal(config.trustProxy, true);
     assert.equal(config.isDev, true);
+  });
+});
+
+// The same parse backs `--port`, `PORT` in the CLI, and `PORT` in the node bundle — one function, so the
+// three cannot drift apart. `test/start.test.mjs` covers what the CLI does with the result.
+describe('parsePort', () => {
+  test('reads a port, including 0 — "any free port"', () => {
+    assert.equal(parsePort('3000', 'PORT'), 3000);
+    assert.equal(parsePort('0', 'PORT'), 0, 'an explicit 0 is a request, not an accident');
+    assert.equal(parsePort('65535', 'PORT'), 65535);
+    assert.equal(parsePort(' 8080 ', 'PORT'), 8080, 'a shell heredoc or a .env file leaves whitespace behind');
+  });
+
+  test('reads blank as unset rather than as port 0', () => {
+    assert.equal(parsePort(undefined, 'PORT'), undefined);
+    assert.equal(parsePort('', 'PORT'), undefined, 'an empty PORT is common in CI and container templates');
+    assert.equal(parsePort('   ', 'PORT'), undefined);
+  });
+
+  test('refuses anything else, naming the source and the value', () => {
+    for (const value of ['abc', '-1', '65536', '3.5', '0x50', '1e3', '+80']) {
+      assert.throws(
+        () => parsePort(value, '--port'),
+        (error) => error instanceof RangeError && error.message.includes('--port') && error.message.includes(JSON.stringify(value)),
+        `${value} is not a port`,
+      );
+    }
   });
 });
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -556,22 +556,38 @@ describe('prerenderStaticRoutes', () => {
     assert.deepEqual(result.skipped, ['/boom']);
   });
 
-  test('rejects param shapes it cannot turn into a single file', async () => {
+  // A route whose paths cannot be computed is unprerenderable, not unservable — the same answer as a
+  // parameterised route with no `staticPaths` at all, one branch above it in the source. These used to
+  // throw out of the pass and take the whole build with them, for routes that work perfectly per request.
+  test('warns and skips a param shape it cannot turn into a single file, rather than failing the build', async () => {
     const cases = [
       { path: '/files/*', staticPaths: async () => [{}], expected: /wildcard segments/ },
       { path: '/docs/:slug{[a-z]+}', staticPaths: async () => [{ slug: 'a' }], expected: /optional\/regex params/ },
       { path: '/docs/:slug', staticPaths: async () => [{ wrong: 'a' }], expected: /without "slug"/ },
+      { path: '/docs/:slug', staticPaths: () => Promise.reject(new Error('the database is down')), expected: /database is down/ },
     ];
     for (const { path, staticPaths, expected } of cases) {
-      await assert.rejects(
-        prerenderStaticRoutes({
+      const warnings = [];
+      const warn = console.warn;
+      console.warn = (message) => warnings.push(String(message));
+      let result;
+      try {
+        result = await prerenderStaticRoutes({
           ssgDir: tempDir(),
-          routes: [{ path, render: 'static', staticPaths, component: async () => ({ default: () => null }) }],
+          routes: [
+            { path, render: 'static', staticPaths, component: async () => ({ default: () => null }) },
+            { path: '/about', render: 'static', component: async () => ({ default: () => null }) },
+          ],
           fetch: okResponse,
-        }),
-        expected,
-        `"${path}" should be rejected`,
-      );
+        });
+      } finally {
+        console.warn = warn;
+      }
+
+      assert.deepEqual(result.skipped, [path], `"${path}" should be skipped`);
+      assert.deepEqual(result.written, ['/about'], 'and the routes around it still prerender');
+      assert.match(warnings.join('\n'), expected, `"${path}" should say why`);
+      assert.match(warnings.join('\n'), /will SSR per request/i, 'and what happens instead');
     }
   });
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -2,7 +2,7 @@
 // exercises indirectly through one happy path. They import the *built* package, so they double as a
 // check that dist is importable from plain Node.
 import assert from 'node:assert/strict';
-import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, sep } from 'node:path';
@@ -407,6 +407,40 @@ describe('readPrerendered', () => {
     assert.notEqual(other.etag, first.etag);
   });
 
+  // What the build's manifest is for: a `render: 'static'` route the build wrote nothing for — no
+  // `staticPaths`, a param it never saw, a page that did not render cleanly — falls through to SSR on every
+  // request, and misses are deliberately not cached, so without the index each of those pays a failed read
+  // first, forever.
+  test('does not touch the store for a path the build did not write', async () => {
+    const dir = tempDir();
+    mkdirSync(join(dir, 'listed'), { recursive: true });
+    writeFileSync(join(dir, 'listed', 'index.html'), '<!DOCTYPE html><p>listed</p>');
+    mkdirSync(join(dir, 'unlisted'), { recursive: true });
+    writeFileSync(join(dir, 'unlisted', 'index.html'), '<!DOCTYPE html><p>unlisted</p>');
+    writeFileSync(join(dir, 'manifest.json'), JSON.stringify({ files: ['listed/index.html'] }));
+
+    assert.ok(await readPrerendered(dir, '/listed'), 'a page the build recorded is served');
+    assert.equal(await readPrerendered(dir, '/unlisted'), null, 'the index is what the store holds — not whatever is on disk');
+    assert.equal(await readPrerendered(dir, '/listed', 'flight'), null, 'per variant: the flight half is best-effort and may not exist');
+  });
+
+  test('reads the store directly when the build left no manifest', async () => {
+    // A build from before there was one. Refusing to serve what it wrote would be worse than the failed
+    // read the index exists to avoid.
+    const dir = tempDir();
+    mkdirSync(join(dir, 'old'), { recursive: true });
+    writeFileSync(join(dir, 'old', 'index.html'), '<!DOCTYPE html><p>old</p>');
+    assert.ok(await readPrerendered(dir, '/old'));
+  });
+
+  test('treats a manifest it cannot parse as no manifest at all', async () => {
+    const dir = tempDir();
+    mkdirSync(join(dir, 'page'), { recursive: true });
+    writeFileSync(join(dir, 'page', 'index.html'), '<!DOCTYPE html><p>page</p>');
+    writeFileSync(join(dir, 'manifest.json'), 'not json');
+    assert.ok(await readPrerendered(dir, '/page'), 'a broken index must not take the store down with it');
+  });
+
   test('returns null for a missing page instead of throwing', async () => {
     assert.equal(await readPrerendered(tempDir(), '/nope'), null);
   });
@@ -458,6 +492,18 @@ describe('prerenderStaticRoutes', () => {
     const decode = (page) => new TextDecoder().decode(page.body);
     assert.equal(decode(await readPrerendered(ssgDir, '/docs/a')), '<!DOCTYPE html><p>ok</p>');
     assert.equal(decode(await readPrerendered(ssgDir, '/docs/a', 'flight')), '0:{"root":"flight"}');
+
+    // The index the reader gates on: every file, under the name a *request* resolves to, and nothing for
+    // the dynamic route that was never prerendered.
+    const manifest = JSON.parse(readFileSync(join(ssgDir, 'manifest.json'), 'utf8'));
+    assert.deepEqual(manifest.files.toSorted(), [
+      'about/index.html',
+      'about/index.rsc',
+      'docs/a/index.html',
+      'docs/a/index.rsc',
+      'docs/b/index.html',
+      'docs/b/index.rsc',
+    ]);
   });
 
   test('renders against siteUrl, so absolute URLs in the output are the deployed ones', async () => {

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -2,7 +2,7 @@
 // exercises indirectly through one happy path. They import the *built* package, so they double as a
 // check that dist is importable from plain Node.
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, sep } from 'node:path';
@@ -21,7 +21,7 @@ import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/ru
 import { beginPageRender, RequestContext } from '../dist/runtime/context.js';
 import { walkHotUpdates } from '../dist/runtime/hot-update.js';
 import { validateRoutesModule, validateServerApp } from '../dist/runtime/validate-entries.js';
-import { MINIMAL_APP_DIR } from './helpers.mjs';
+import { MINIMAL_APP_DIR, TESTBED_DIR } from './helpers.mjs';
 
 const tempDirs = [];
 function tempDir() {
@@ -935,6 +935,67 @@ describe('server bundle externals', () => {
     );
     assert.equal(verdict('D:/app/src/components/home.tsx'), undefined, 'forward-slash drive paths too');
     assert.equal(verdict('\\\\server\\share\\home.tsx'), undefined, 'and UNC paths');
+  });
+});
+
+describe('the security-middleware build warning', () => {
+  /** The minimal app somewhere disposable, plus whatever `src/server.ts` the case wants. */
+  function appWithServer(serverSource) {
+    const dir = mkdtempSync(join(tmpdir(), 'rshono-warn-'));
+    symlinkSync(join(MINIMAL_APP_DIR, 'node_modules'), join(dir, 'node_modules'), 'junction');
+    cpSync(join(MINIMAL_APP_DIR, 'package.json'), join(dir, 'package.json'));
+    cpSync(join(MINIMAL_APP_DIR, 'src'), join(dir, 'src'), { recursive: true });
+    if (serverSource !== null) writeFileSync(join(dir, 'src', 'server.ts'), serverSource);
+    after(() => {
+      // The link, not what it points at: `node_modules` is the fixture's, borrowed rather than copied.
+      unlinkSync(join(dir, 'node_modules'));
+      rmSync(dir, { recursive: true, force: true });
+    });
+    return dir;
+  }
+
+  /** What `createConfigs` warns about for `rootDir`, as one string. Builds only — `dev` says nothing. */
+  function warningsFor(rootDir, { isDev = false } = {}) {
+    const warn = console.warn;
+    const lines = [];
+    console.warn = (...args) => lines.push(args.join(' '));
+    try {
+      createConfigs({ rootDir, isDev, config: {}, preset: NODE_PRESET });
+    } finally {
+      console.warn = warn;
+    }
+    return lines.join('\n');
+  }
+
+  test('an app with no src/server.ts is told it has neither control', () => {
+    assert.match(warningsFor(MINIMAL_APP_DIR), /No src\/server\.ts/);
+  });
+
+  test('an app whose src/server.ts never registers bodyLimit is told about the body cap', () => {
+    // Having a src/server.ts is not the same as having the cap in it, and this half used to be warned
+    // about nowhere: the first check only ever asked whether the file existed. Every `'use server'`
+    // export is a public POST endpoint, and the action path buffers the whole body before it can decide
+    // anything about it.
+    const dir = appWithServer("import { Hono } from 'hono';\nexport default new Hono();\n");
+    const warnings = warningsFor(dir);
+    assert.match(warnings, /No bodyLimit\(\) anywhere in src\//);
+    assert.doesNotMatch(warnings, /No src\/server\.ts/, 'the file is there — only the cap is missing');
+  });
+
+  test('the scan is the whole of src/, so a cap registered from a helper module counts', () => {
+    // A textual scan of one file would call this app unprotected. The failure mode of getting it wrong is
+    // a warning nobody needed, so it reads wide rather than narrow.
+    const dir = appWithServer("import { Hono } from 'hono';\nimport { security } from './security';\nexport default new Hono().use(security());\n");
+    writeFileSync(
+      join(dir, 'src', 'security.ts'),
+      "import { bodyLimit } from 'hono/body-limit';\nexport const security = () => bodyLimit({ maxSize: 1024 });\n",
+    );
+    assert.equal(warningsFor(dir), '', 'a registered cap must not be reported as missing');
+  });
+
+  test('the testbed, which registers both, is warned about nothing — and dev is never warned at all', () => {
+    assert.equal(warningsFor(TESTBED_DIR), '');
+    assert.equal(warningsFor(MINIMAL_APP_DIR, { isDev: true }), '', 'a rebuild would print it every time');
   });
 });
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -17,6 +17,7 @@ import { resolveServerConfig } from '../dist/server/server-config.js';
 import { createPageCache, ssgAssetPath, ssgFilePath } from '../dist/server/prerendered.js';
 import { prerenderStaticRoutes, readPrerendered, resolveSiteOrigin } from '../dist/server/ssg.js';
 import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
+import { asksForRsc, createRscRequest, isActionRequest, parseRenderRequest, wantsRsc } from '../dist/runtime/request.js';
 import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/runtime/control.js';
 import { beginPageRender, RequestContext } from '../dist/runtime/context.js';
 import { walkHotUpdates } from '../dist/runtime/hot-update.js';
@@ -935,6 +936,102 @@ describe('server bundle externals', () => {
     );
     assert.equal(verdict('D:/app/src/components/home.tsx'), undefined, 'forward-slash drive paths too');
     assert.equal(verdict('\\\\server\\share\\home.tsx'), undefined, 'and UNC paths');
+  });
+});
+
+describe('parseRenderRequest', () => {
+  const BASE = 'https://app.test/page';
+  const parse = (init) => parseRenderRequest(new Request(BASE, init));
+
+  test('classifies a GET by the RSC header alone', () => {
+    assert.deepEqual(parse({}), { kind: 'document' });
+    assert.deepEqual(parse({ headers: { RSC: '1' } }), { kind: 'rsc' });
+    // Exactly two states — that is what makes `Vary: RSC` cheap enough to put on a cacheable response.
+    assert.deepEqual(parse({ headers: { RSC: '0' } }), { kind: 'document' });
+    assert.deepEqual(parse({ headers: { RSC: 'true' } }), { kind: 'document' });
+    // An action id on a GET is not a shape the union can hold, and a GET must never run one.
+    assert.deepEqual(parse({ headers: { 'x-rsc-action': 'abc' } }), { kind: 'document' });
+  });
+
+  test("a POST is a client-initiated action exactly when it carries 'x-rsc-action'", () => {
+    // Which branch a POST takes is a security boundary, not just dispatch. `x-rsc-action` is not a
+    // CORS-safelisted header, so a page on another origin cannot send one without a preflight the framework
+    // never answers — which is why this branch carries no origin check of its own. If the classification
+    // ever moved to something a cross-origin form *can* send, that defence would be gone with no test
+    // failing anywhere else. See `SECURITY.md` and `refusesCrossSiteForm`.
+    assert.deepEqual(parse({ method: 'POST', headers: { 'x-rsc-action': 'abc' }, body: '[]' }), { kind: 'rsc-action', actionId: 'abc' });
+    // The header decides even when the body is form-shaped: a client-initiated call is not forgeable
+    // whatever it is encoded as.
+    assert.deepEqual(parse({ method: 'POST', headers: { 'x-rsc-action': 'abc', 'content-type': 'multipart/form-data; boundary=x' }, body: '' }), {
+      kind: 'rsc-action',
+      actionId: 'abc',
+    });
+    assert.deepEqual(parse({ method: 'POST', headers: { 'x-rsc-action': '' }, body: '[]' }), { kind: 'document' }, 'an empty id names nothing');
+  });
+
+  test('a POST is a form action exactly for the content types a browser can send cross-origin', () => {
+    // These two need no preflight, which is what makes this the forgeable shape and the one
+    // `refusesCrossSiteForm` stands in front of.
+    for (const contentType of ['application/x-www-form-urlencoded', 'multipart/form-data; boundary=----x', 'MULTIPART/FORM-DATA; boundary=y']) {
+      assert.deepEqual(parse({ method: 'POST', headers: { 'content-type': contentType }, body: 'x=1' }), { kind: 'form-action' }, contentType);
+    }
+    // Matched as a prefix, so the `; charset=UTF-8` a browser appends does not fall out of the branch — and
+    // erring wide is the safe direction here: an over-matched POST lands on the guarded branch and decodes to
+    // nothing, where an under-matched one would land on a branch with no origin check.
+    assert.deepEqual(parse({ method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencodedX' }, body: 'x=1' }), {
+      kind: 'form-action',
+    });
+    // Anything else is not an action at all — it renders the page and runs nothing, so a `text/plain` POST
+    // without the header cannot reach an action however it is aimed.
+    for (const contentType of ['application/json', 'text/plain', 'text/html', 'application/xml']) {
+      assert.deepEqual(parse({ method: 'POST', headers: { 'content-type': contentType }, body: '{}' }), { kind: 'document' }, contentType);
+    }
+    assert.deepEqual(parse({ method: 'POST', body: 'x=1' }), { kind: 'document' }, 'no content-type at all');
+  });
+
+  test('what each shape means downstream', () => {
+    const shapes = {
+      document: parse({}),
+      rsc: parse({ headers: { RSC: '1' } }),
+      'form-action': parse({ method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: 'x=1' }),
+      'rsc-action': parse({ method: 'POST', headers: { 'x-rsc-action': 'abc' }, body: '[]' }),
+    };
+    assert.deepEqual(Object.fromEntries(Object.entries(shapes).map(([name, shape]) => [name, [wantsRsc(shape), isActionRequest(shape)]])), {
+      document: [false, false],
+      rsc: [true, false],
+      // A no-JS form post answers with a document; a client-initiated call answers with a payload.
+      'form-action': [false, true],
+      'rsc-action': [true, true],
+    });
+  });
+
+  test('asksForRsc reads the same header without parsing the rest', () => {
+    // The prerendered-page path takes it on every GET, so it never builds a `RenderRequest` it would drop.
+    assert.equal(asksForRsc(new Request(BASE, { headers: { RSC: '1' } })), true);
+    assert.equal(asksForRsc(new Request(BASE)), false);
+    assert.equal(asksForRsc(new Request(BASE, { method: 'POST', headers: { 'x-rsc-action': 'abc' }, body: '[]' })), false, 'RSC, not the action id');
+  });
+
+  test('createRscRequest round-trips through the parser it is read by', () => {
+    // `location` is the browser global the client runtime resolves a relative href against.
+    const location = globalThis.location;
+    globalThis.location = { origin: 'https://app.test' };
+    try {
+      const navigation = createRscRequest('/docs?q=1');
+      assert.equal(navigation.method, 'GET');
+      assert.equal(navigation.url, 'https://app.test/docs?q=1');
+      assert.deepEqual(parseRenderRequest(navigation), { kind: 'rsc' });
+
+      const action = createRscRequest('/docs', { id: 'abc123', body: '[]' });
+      assert.equal(action.method, 'POST');
+      assert.deepEqual(parseRenderRequest(action), { kind: 'rsc-action', actionId: 'abc123' });
+      // The header the whole cross-origin argument rests on has to be the one actually sent.
+      assert.equal(action.headers.get('x-rsc-action'), 'abc123');
+      assert.equal(action.headers.get('rsc'), '1');
+    } finally {
+      if (location === undefined) delete globalThis.location;
+      else globalThis.location = location;
+    }
   });
 });
 

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -1639,6 +1639,14 @@ describe('validateRoutesModule', () => {
     rejects([{ ...endpoint, method: 'head' }], /A HEAD is dispatched as a GET, so use 'get'/);
   });
 
+  test('takes a list of methods, and refuses the lists that are mistakes', () => {
+    assert.deepEqual(validateRoutesModule([{ ...endpoint, method: ['get', 'delete'] }]).routes[0].method, ['get', 'delete']);
+    // Named member by member, so the message points at the bad one rather than printing the array.
+    rejects([{ ...endpoint, method: ['get', 'HEAD'] }], /has method "HEAD", which is not one of get, post/);
+    rejects([{ ...endpoint, method: [] }], /has an empty `method` list/);
+    rejects([{ ...endpoint, method: ['get', 'all'] }], /has 'all' inside a `method` list/);
+  });
+
   // The one that built cleanly, exited 0 and said nothing: Hono matches in registration order.
   test('refuses a route every method of which the table already answers', () => {
     rejects(
@@ -1646,6 +1654,14 @@ describe('validateRoutesModule', () => {
       /routes\[1\] \("\/"\) would never run — routes\[0\] \("\/"\) already answers GET, POST \//,
     );
     rejects([endpoint, { ...endpoint, method: 'get' }], /already answers GET \/api\/x/, 'an `all` endpoint claims every method');
+    rejects(
+      [
+        { ...endpoint, method: ['get', 'post'] },
+        { ...endpoint, method: 'post' },
+      ],
+      /already answers POST \/api\/x/,
+      'a listed method is claimed like any other',
+    );
     rejects([{ ...endpoint, path: '/' }, page], /already answers GET, POST \//, 'an endpoint shadows a page at the same path too');
   });
 
@@ -1659,6 +1675,8 @@ describe('validateRoutesModule', () => {
       ],
       // A catch-all behind a route claiming one method of the path: it still answers PUT, DELETE, …
       [{ ...endpoint, method: 'post' }, endpoint],
+      // And behind one claiming two of them.
+      [{ ...endpoint, method: ['get', 'post'] }, endpoint],
       // Overlapping *patterns* are the router's business, and specific-before-generic is the point.
       [
         { ...page, path: '/docs/getting-started' },

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -20,7 +20,7 @@ import { prerenderStaticRoutes, readPrerendered, resolveSiteOrigin } from '../di
 import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
 import { asksForRsc, createRscRequest, isActionRequest, parseRenderRequest, wantsRsc } from '../dist/runtime/request.js';
 import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/runtime/control.js';
-import { beginPageRender, onServerError, publicUrl, reportServerError, RequestContext } from '../dist/runtime/context.js';
+import { beginPageRender, getRequestContext, onServerError, publicUrl, reportServerError, RequestContext, runWithContext } from '../dist/runtime/context.js';
 import { walkHotUpdates } from '../dist/runtime/hot-update.js';
 import { validateRoutesModule, validateServerApp } from '../dist/runtime/validate-entries.js';
 import { MINIMAL_APP_DIR, TESTBED_DIR } from './helpers.mjs';
@@ -304,6 +304,45 @@ describe('injectFlightPayload', () => {
 // Two fields, because only two things here are decided by the build. The CSRF check, the CSP and the
 // body cap used to live alongside them and are now Hono middleware an app registers in src/server.ts
 // — see prod-config.test.mjs, which exercises them over HTTP rather than through a resolver.
+// The ambient context, which every `getRequestContext()` call in an app resolves through. Sequential tests
+// cannot see the failure that matters here: one request reading another's context.
+describe('runWithContext', () => {
+  const contextFor = (path) => ({ req: { url: `http://example.test${path}`, param: () => ({}) }, env: {} });
+
+  test('keeps one context per flow across suspensions', async () => {
+    const seen = [];
+    /** Reads the ambient context either side of an await, so what is asserted is that the store survives one. */
+    const flow = (path, delay) =>
+      runWithContext(contextFor(path), async () => {
+        const before = getRequestContext().url.pathname;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        const after = getRequestContext().url.pathname;
+        seen.push({ path, before, after });
+      });
+
+    // Interleaved deliberately: the longest-running flow starts first and finishes last, so every other
+    // flow enters and leaves inside it.
+    await Promise.all([flow('/a', 30), flow('/b', 5), flow('/c', 15), flow('/d', 0)]);
+
+    assert.equal(seen.length, 4);
+    for (const { path, before, after } of seen) {
+      assert.equal(before, path, `${path} read the wrong context before its await`);
+      assert.equal(after, path, `${path} read the wrong context after its await — another flow's store leaked in`);
+    }
+  });
+
+  test('throws outside a flow rather than resolving to the last one that ran', () => {
+    assert.throws(() => getRequestContext(), /outside a request/);
+  });
+
+  test('hands back the same wrapper for the same request, and a different one for another', () => {
+    const c = contextFor('/a');
+    const [first, second] = runWithContext(c, () => [getRequestContext(), getRequestContext()]);
+    assert.equal(first, second, 'memoised per request, so repeated calls are one object');
+    assert.notEqual(runWithContext(contextFor('/a'), getRequestContext), first, 'and never shared between requests');
+  });
+});
+
 // The single funnel every caught server-side error goes through. `prod.test.mjs` covers the happy path over
 // HTTP; these are the parts an app only meets when something else has already gone wrong.
 describe('reportServerError', () => {

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -218,6 +218,52 @@ describe('injectFlightPayload', () => {
       assert.equal(released, 1);
     });
   });
+
+  // A slow client must park the producers rather than let them run to completion into the readable's queue.
+  // The payload pump is the half that had no gate at all: it writes into the transform's controller from a
+  // detached promise, so nothing about the transform's own backpressure applied to it.
+  test('stops producing while the consumer is not reading', async () => {
+    let htmlPulled = 0;
+    let flushes = 0;
+    // Shaped like React: a run of chunks per flush, flushes separated by a macrotask.
+    const html = new ReadableStream({
+      async pull(controller) {
+        if (htmlPulled % 5 === 0) {
+          flushes++;
+          await new Promise((resolve) => setImmediate(resolve));
+        }
+        if (++htmlPulled > 500) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode('<p>hi</p>'));
+      },
+    });
+    let flightPulled = 0;
+    const flight = new ReadableStream({
+      pull(controller) {
+        if (++flightPulled > 500) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(`${flightPulled}:"hi"\n`));
+      },
+    });
+
+    const reader = html.pipeThrough(injectFlightPayload(flight)).getReader();
+    await reader.read(); // one chunk, then stall — a client that stopped reading
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    assert.ok(flightPulled < 10, `the payload must park, not run to completion (pulled ${flightPulled})`);
+    assert.ok(htmlPulled < 20, `the document must park, not run to completion (pulled ${htmlPulled})`);
+    assert.ok(flushes >= 1, 'sanity: the source did produce');
+
+    // And reading again has to resume it, rather than having deadlocked on a permit nobody releases.
+    const before = flightPulled;
+    for (let i = 0; i < 20; i++) await reader.read();
+    assert.ok(flightPulled > before, 'reading again must resume the payload');
+    await reader.cancel();
+  });
 });
 
 // Two fields, because only two things here are decided by the build. The CSRF check, the CSP and the

--- a/packages/core/test/unit.test.mjs
+++ b/packages/core/test/unit.test.mjs
@@ -20,7 +20,15 @@ import { prerenderStaticRoutes, readPrerendered, resolveSiteOrigin } from '../di
 import { injectFlightPayload } from '../dist/runtime/flight-inject.js';
 import { asksForRsc, createRscRequest, isActionRequest, parseRenderRequest, wantsRsc } from '../dist/runtime/request.js';
 import { isControlDigest, parseRedirectDigest, RedirectSignal } from '../dist/runtime/control.js';
-import { beginPageRender, getRequestContext, onServerError, publicUrl, reportServerError, RequestContext, runWithContext } from '../dist/runtime/context.js';
+import {
+  beginPageRender,
+  getRequestContext,
+  onServerError,
+  publicUrl,
+  reportServerError,
+  RequestContext,
+  runWithContext,
+} from '../dist/runtime/context.js';
 import { walkHotUpdates } from '../dist/runtime/hot-update.js';
 import { validateRoutesModule, validateServerApp } from '../dist/runtime/validate-entries.js';
 import { MINIMAL_APP_DIR, TESTBED_DIR } from './helpers.mjs';
@@ -103,9 +111,7 @@ describe('injectFlightPayload', () => {
       });
     };
 
-    const html = await readAll(
-      batchedStreamOf(['<html><body><p>hi</p></bo', 'dy></html>']).pipeThrough(injectFlightPayload(streamOf(['0:"hi"\n']))),
-    );
+    const html = await readAll(batchedStreamOf(['<html><body><p>hi</p></bo', 'dy></html>']).pipeThrough(injectFlightPayload(streamOf(['0:"hi"\n']))));
     assert.equal(countOf(html, '</body></html>'), 1, 'exactly one trailer, however the batches fell');
     assert.ok(html.indexOf('__FLIGHT_DATA') < html.indexOf('</body></html>'), 'the script must not land inside the trailer');
     assert.match(html, /<script>\(self\.__FLIGHT_DATA\|\|=\[\]\)\.push\("0:\\"hi\\"\\n"\)<\/script><\/body><\/html>$/);

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -51,8 +51,8 @@
   },
   "devDependencies": {
     "@clack/prompts": "^1.7.0",
-    "@rspack/core": "2.2.0",
-    "@types/node": "^26.2.0",
+    "@rspack/core": "2.2.1",
+    "@types/node": "^26.4.0",
     "@rshono/core": "workspace:*",
     "typescript": "^7.0.2"
   }

--- a/packages/create/src/generated/framework.ts
+++ b/packages/create/src/generated/framework.ts
@@ -18,7 +18,7 @@ export const FRAMEWORK_DEPS = {
   react: '19.2.8',
   'react-dom': '19.2.8',
   typescript: '^7.0.2',
-  '@types/node': '^26.2.0',
+  '@types/node': '^26.4.0',
   '@types/react': '^19.2.18',
 } as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   react: 19.2.8
   react-dom: 19.2.8
-  react-server-dom-rspack: 0.0.3
-  '@rspack/core': 2.1.7
+  react-server-dom-rspack: 0.1.0
+  '@rspack/core': 2.2.0
 
 importers:
 
@@ -120,7 +120,7 @@ importers:
         version: 8.5.26
       postcss-loader:
         specifier: ^8.2.1
-        version: 8.2.1(@rspack/core@2.1.7)(postcss@8.5.26)(typescript@6.0.3)
+        version: 8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -139,17 +139,17 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(hono@4.13.5)
       '@rspack/core':
-        specifier: 2.1.7
-        version: 2.1.7
+        specifier: 2.2.0
+        version: 2.2.0
       '@rspack/plugin-react-refresh':
         specifier: 2.0.2
-        version: 2.0.2(@rspack/core@2.1.7)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0)(react-refresh@0.18.0)
       react-refresh:
         specifier: 0.18.0
         version: 0.18.0
       react-server-dom-rspack:
-        specifier: 0.0.3
-        version: 0.0.3(@rspack/core@2.1.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 0.1.0
+        version: 0.1.0(@rspack/core@2.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@playwright/test':
         specifier: ^1.62.1
@@ -222,7 +222,7 @@ importers:
         version: 8.5.26
       postcss-loader:
         specifier: ^8.2.1
-        version: 8.2.1(@rspack/core@2.1.7)(postcss@8.5.26)(typescript@7.0.2)
+        version: 8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@7.0.2)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -236,8 +236,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rspack/core':
-        specifier: 2.1.7
-        version: 2.1.7
+        specifier: 2.2.0
+        version: 2.2.0
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -373,17 +373,14 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
-
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -807,76 +804,88 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@rspack/binding-darwin-arm64@2.1.7':
-    resolution: {integrity: sha512-DwxzrXRctueP/3Pyom9JHcIsRShuEAlHb+mrE5OPT+4cdHI1UnJpbzEvEDLTo4IKJhDb3vjXdHLtjqtL0SYbeA==}
+  '@rspack/binding-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-KAVVT7hp3NBjtc/RY2UtOjzzc8i+s4pIhW1p52UV+Aev6ywQCu3dXwkHTonpPvJO3hqLXc4zIMH5l4HbMqBm4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.7':
-    resolution: {integrity: sha512-kPbrYvR/XUHfAMgRVq3QnC71DW/qjwsPj+3hEUuEnRmlploPNy9u8Szf1IHKSVUSrVZBTgDyMoZQdxYLfhResw==}
+  '@rspack/binding-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-rzyJCX99aFwl540trsVMNZOgK4+IFm2d5+YeP+RdNo9Uprxloz8vHz0J4dYtaq6MRiCAyM60dAwEa3wJMwqWAQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.7':
-    resolution: {integrity: sha512-VFB+YXM3kZ6IIuLV64H3vgnwqvQIIaqfR/aeGwuxYvwcZsrgblSBmXMeDULdgDjqP8Yr0VaFMBBiD9OtG5KdFw==}
+  '@rspack/binding-linux-arm64-gnu@2.2.0':
+    resolution: {integrity: sha512-0t8QOiOMcBV7RvPSsTJ5DQ4QCK6FIyUZy77qbxnS6asGTOXPZZn7V5cL26IxEv/wuHdQ6tQOXheau1fi+gGyBQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.1.7':
-    resolution: {integrity: sha512-Mzbxyg0aJ+ITj526Iuz0enEDYY6WxhFIwEKXqwjQh+Vpd5v/+aPzPo83sSQVX/3puBV1sbmviTURbh6N9e1fvA==}
+  '@rspack/binding-linux-arm64-musl@2.2.0':
+    resolution: {integrity: sha512-BAvCukqcuHxUdE294ITCohvhVkEklW8RbkKkR36Uo0WyIiMPGrnvPjARPn0/4Q4xMAz7lUmC60sZrvJHlAOKMw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.7':
-    resolution: {integrity: sha512-mpazwgT/Pse1720mvEJsoXfPkJ+enj0xUqpbe/wL6aedwjGT+9jJNB8HTJXE4XBX0UO7umGqcJMeKA6YsD2CDA==}
+  '@rspack/binding-linux-ppc64-gnu@2.2.0':
+    resolution: {integrity: sha512-nCHqZLv/E8nm2ccGkb00F5DQtXxzGy3W3X73ArA+N0+zXJUnzRcSRSwr7AE8pVgP/FYfX4yMFgUXy0g0YxYGRA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.2.0':
+    resolution: {integrity: sha512-CA3WEqKFDI6FAZTnCho2n9pmdPWZYAW/S8mqgxd0cx2Jix43at3VyLxhCC7ED5A9WBSFn/AdHaIbVtgoQHVhWA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.7':
-    resolution: {integrity: sha512-oU/l3soPRsDEWn7KZic+npyTMM2N1kRdHjoJ+L5IUBXs8bjdTXPLoyTbTdIOza5ZSoT4+UeEiEryj4BB0tQE5w==}
+  '@rspack/binding-linux-riscv64-musl@2.2.0':
+    resolution: {integrity: sha512-kHB960oClkoPRPZ6sdkhRvqbdRIlbpIMYd/Tbxfmn3DWQahiCk1pkUFJbOtFq3EgESxZISV4THl442W2Y57HvQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.1.7':
-    resolution: {integrity: sha512-7Gtpl3h3jtnOpk1mYQE8mRndXAO2ibI8mnAbs7klevdKey+ZHneWMoMi2yOMQhhI/ifWEFxDzyGJ8bdxo0XTsA==}
+  '@rspack/binding-linux-s390x-gnu@2.2.0':
+    resolution: {integrity: sha512-lVBdiffVo1jq0P0jT36jNou2suLB4ueQI4aWUs+HM+h67YPBtVKWu/mo5Wh59+8nowgcZmYaFM5hdH69963I9w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.2.0':
+    resolution: {integrity: sha512-M49UaWspE0YJ3268DsquD8idEQTfjBDMvO/I8qccV/Z5T+Q98FJ+kIs5liUaTWb48OIbDEK+8ZKx5QzLbfVN6g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.1.7':
-    resolution: {integrity: sha512-w+whI2Uy+DYkGN+MVkzMFWweL7B/s1gMqX+nvTE1vhOy3hGV0VyA9H6lqWjSD3I+eGkpYhN9Pr244cYnLpZOUQ==}
+  '@rspack/binding-linux-x64-musl@2.2.0':
+    resolution: {integrity: sha512-YYbs0wmey+5blhEQDE4Dax3TwJtqfGwe2QBm3OLphlBHo/fcZVvimzKkMV0/pVrZTLy2z5ZAwNhGMY64bNr77w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.7':
-    resolution: {integrity: sha512-cDVgvzRdTgxaeM+a5Lx0+7/VAvunvwO0wNtQ3ATQGOtFCW5b7cUzhNPcytH5ZSJTnFWuxinlGwtar5yfcnkdZQ==}
+  '@rspack/binding-wasm32-wasi@2.2.0':
+    resolution: {integrity: sha512-rerLPTN/HD4EvLNWs3O2N+Eb37eGvLRIP3dXXc3n+UzTebOepAsahNn44vXeRBsE4m/pHkpDJjwgWTytgQ2gBw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.7':
-    resolution: {integrity: sha512-JDd85+iYwUvaG9Zrt5X7oIxRZRiTW+76FwkRakoXNy/5VAWQW32Jq4ESjSVz6l6mh0KnZxPq3TLMugacCPnLjw==}
+  '@rspack/binding-win32-arm64-msvc@2.2.0':
+    resolution: {integrity: sha512-JUAmnbOQYGTRyX28vls/MOMonZWcmcCi5YtEq6YMc8Xqh3Qx0HUwaLM/I1xr/N9BX3b8CV0dQDOpNuBc2ei+CA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.7':
-    resolution: {integrity: sha512-y9PKEs6v9BLHV0i/4eaIRtxpATvSgcf/VYQkMT8mp+qWlPjUwDQNwU2ueWVGpff6INO+YAa7zobzziNFRgO7Lg==}
+  '@rspack/binding-win32-ia32-msvc@2.2.0':
+    resolution: {integrity: sha512-wOmQRUaOG0eWH/fnfslA9yK9xKfaq9X+3Xa1TdTJnTqlo0ARJYs6A+Lzjbs7cxdY/o1f12Xe00BG3nQozReUOg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.7':
-    resolution: {integrity: sha512-BjkOzcPY/K8YlRRvyywz0mDWk89MMxqAMhDmgBXCWorh1IjgKTsWDJ2lCGIM8M9CZXUG3khom8AfrOGwRT2I+g==}
+  '@rspack/binding-win32-x64-msvc@2.2.0':
+    resolution: {integrity: sha512-v6/3bFr9+i7hRpgulL9b5qCvZL0VgR4vQGQNqOWezUzZmPUj9LYpvB0L9xZIVwDQ2ug/xBiA58bfg5IbESgoyw==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.7':
-    resolution: {integrity: sha512-wYqi8TY30hsIzLry503o/Uqu7y9Ec7pEwN5TVmB7Pb3xHrR2eHsQPzdpF/GkCLUjQSgD2Es3CDVV1mr6zO/78g==}
+  '@rspack/binding@2.2.0':
+    resolution: {integrity: sha512-nxZzJqqB0EmEKp6qjzFNkBb/SgGt0k0DSENrLvAJgvVvrm3waVsubD0cfxtPlZY/rd5SzadzxWGEHRyFcds5nA==}
 
-  '@rspack/core@2.1.7':
-    resolution: {integrity: sha512-d5Ju3zXzGgbqQWvlMlLUtek2eFPIzsFe2QOF4nwTAknxo/4OZ64t+kPT9nM6fr3aZX93VK0R3v02/kZYIRrV9Q==}
+  '@rspack/core@2.2.0':
+    resolution: {integrity: sha512-3W7oX0BAHbK4VlknH3lfyfRvupzxdZtyEa+DfKmdjzmIAcqYtHnFd0nLqp5dzitDPyDI1TIKkDhpB0AZJn0pVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -890,7 +899,7 @@ packages:
   '@rspack/plugin-react-refresh@2.0.2':
     resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
     peerDependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       '@rspack/core':
@@ -1829,7 +1838,7 @@ packages:
     resolution: {integrity: sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
       postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.0.0
     peerDependenciesMeta:
@@ -1876,11 +1885,11 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-server-dom-rspack@0.0.3:
-    resolution: {integrity: sha512-V+sf4LO12QdQ+Ao6xxweJqGKNU5wVBAGZmL4jkKbBIvJ5MaNo0TxndXXIVdDHQPXJrkzvBPiwbzaFDK2eOBLkg==}
+  react-server-dom-rspack@0.1.0:
+    resolution: {integrity: sha512-KqDzmxBUZEcAphwg/PnEHOBkqTJjesTmLoBygLHie1gkiLINiZuVKPRccS6qDzfdj9ccYCaJ743IDYVh0wPf/w==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
       react: 19.2.8
       react-dom: 19.2.8
 
@@ -2248,14 +2257,9 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.11.2':
-    dependencies:
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -2264,7 +2268,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2531,10 +2535,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -2554,70 +2558,78 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@rspack/binding-darwin-arm64@2.1.7':
+  '@rspack/binding-darwin-arm64@2.2.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.7':
+  '@rspack/binding-darwin-x64@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.7':
+  '@rspack/binding-linux-arm64-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.7':
+  '@rspack/binding-linux-arm64-musl@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.7':
+  '@rspack/binding-linux-ppc64-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.1.7':
+  '@rspack/binding-linux-riscv64-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.7':
+  '@rspack/binding-linux-riscv64-musl@2.2.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.7':
+  '@rspack/binding-linux-s390x-gnu@2.2.0':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.7':
+  '@rspack/binding-linux-x64-gnu@2.2.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.2.0':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.2.0':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.7':
+  '@rspack/binding-win32-arm64-msvc@2.2.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.7':
+  '@rspack/binding-win32-ia32-msvc@2.2.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.7':
+  '@rspack/binding-win32-x64-msvc@2.2.0':
     optional: true
 
-  '@rspack/binding@2.1.7':
+  '@rspack/binding@2.2.0':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.7
-      '@rspack/binding-darwin-x64': 2.1.7
-      '@rspack/binding-linux-arm64-gnu': 2.1.7
-      '@rspack/binding-linux-arm64-musl': 2.1.7
-      '@rspack/binding-linux-riscv64-gnu': 2.1.7
-      '@rspack/binding-linux-riscv64-musl': 2.1.7
-      '@rspack/binding-linux-x64-gnu': 2.1.7
-      '@rspack/binding-linux-x64-musl': 2.1.7
-      '@rspack/binding-wasm32-wasi': 2.1.7
-      '@rspack/binding-win32-arm64-msvc': 2.1.7
-      '@rspack/binding-win32-ia32-msvc': 2.1.7
-      '@rspack/binding-win32-x64-msvc': 2.1.7
+      '@rspack/binding-darwin-arm64': 2.2.0
+      '@rspack/binding-darwin-x64': 2.2.0
+      '@rspack/binding-linux-arm64-gnu': 2.2.0
+      '@rspack/binding-linux-arm64-musl': 2.2.0
+      '@rspack/binding-linux-ppc64-gnu': 2.2.0
+      '@rspack/binding-linux-riscv64-gnu': 2.2.0
+      '@rspack/binding-linux-riscv64-musl': 2.2.0
+      '@rspack/binding-linux-s390x-gnu': 2.2.0
+      '@rspack/binding-linux-x64-gnu': 2.2.0
+      '@rspack/binding-linux-x64-musl': 2.2.0
+      '@rspack/binding-wasm32-wasi': 2.2.0
+      '@rspack/binding-win32-arm64-msvc': 2.2.0
+      '@rspack/binding-win32-ia32-msvc': 2.2.0
+      '@rspack/binding-win32-x64-msvc': 2.2.0
 
-  '@rspack/core@2.1.7':
+  '@rspack/core@2.2.0':
     dependencies:
-      '@rspack/binding': 2.1.7
+      '@rspack/binding': 2.2.0
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.7)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
 
   '@shikijs/core@4.4.3':
     dependencies:
@@ -3495,25 +3507,25 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-loader@8.2.1(@rspack/core@2.1.7)(postcss@8.5.26)(typescript@6.0.3):
+  postcss-loader@8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@6.0.3):
     dependencies:
       cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.7.0
       postcss: 8.5.26
       semver: 7.8.5
     optionalDependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.2.1(@rspack/core@2.1.7)(postcss@8.5.26)(typescript@7.0.2):
+  postcss-loader@8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@7.0.2):
     dependencies:
       cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.7.0
       postcss: 8.5.26
       semver: 7.8.5
     optionalDependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
     transitivePeerDependencies:
       - typescript
 
@@ -3544,9 +3556,9 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-server-dom-rspack@0.0.3(@rspack/core@2.1.7)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-server-dom-rspack@0.1.0(@rspack/core@2.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@rspack/core': 2.1.7
+      '@rspack/core': 2.2.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   react: 19.2.8
   react-dom: 19.2.8
   react-server-dom-rspack: 0.1.0
-  '@rspack/core': 2.2.0
+  '@rspack/core': 2.2.1
 
 importers:
 
@@ -16,13 +16,13 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.1(jiti@2.7.0))
+        version: 10.0.1(eslint@10.9.1(jiti@2.7.0))
       eslint:
-        specifier: ^10.8.1
-        version: 10.8.1(jiti@2.7.0)
+        specifier: ^10.9.1
+        version: 10.9.1(jiti@2.7.0)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.8.1(jiti@2.7.0))
+        version: 7.1.1(eslint@10.9.1(jiti@2.7.0))
       globals:
         specifier: ^17.11.0
         version: 17.11.0
@@ -36,8 +36,8 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
       typescript-eslint:
-        specifier: ^8.67.0
-        version: 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
+        specifier: ^8.68.0
+        version: 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
 
   apps/testbed:
     dependencies:
@@ -61,8 +61,8 @@ importers:
         version: link:../../packages/core/test/fixtures/external-dep
     devDependencies:
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^26.4.0
+        version: 26.4.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -88,11 +88,11 @@ importers:
         specifier: ^4.13.5
         version: 4.13.5
       markdown-it:
-        specifier: ^15.0.0
-        version: 15.0.0
+        specifier: ^15.0.1
+        version: 15.0.1
       markdown-it-anchor:
         specifier: ^9.2.1
-        version: 9.2.1(@types/markdown-it@14.1.2)(markdown-it@15.0.0)
+        version: 9.2.1(@types/markdown-it@14.2.0)(markdown-it@15.0.1)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -107,11 +107,11 @@ importers:
         specifier: ^4.3.3
         version: 4.3.3
       '@types/markdown-it':
-        specifier: ^14.1.2
-        version: 14.1.2
+        specifier: ^14.2.0
+        version: 14.2.0
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^26.4.0
+        version: 26.4.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -120,16 +120,16 @@ importers:
         version: 8.5.26
       postcss-loader:
         specifier: ^8.2.1
-        version: 8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@6.0.3)
+        version: 8.2.1(@rspack/core@2.2.1)(postcss@8.5.26)(typescript@7.0.2)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
       typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       wrangler:
-        specifier: ^4.123.0
-        version: 4.123.0
+        specifier: ^4.127.1
+        version: 4.127.1
 
   packages/benchmarks: {}
 
@@ -139,30 +139,30 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(hono@4.13.5)
       '@rspack/core':
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.2.1
+        version: 2.2.1
       '@rspack/plugin-react-refresh':
         specifier: 2.0.2
-        version: 2.0.2(@rspack/core@2.2.0)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)
       react-refresh:
         specifier: 0.18.0
         version: 0.18.0
       react-server-dom-rspack:
         specifier: 0.1.0
-        version: 0.1.0(@rspack/core@2.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.1.0(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^26.4.0
+        version: 26.4.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
       '@types/react-dom':
-        specifier: ^19.2.4
-        version: 19.2.4(@types/react@19.2.18)
+        specifier: ^19.2.5
+        version: 19.2.5(@types/react@19.2.18)
       hono:
         specifier: ^4.13.5
         version: 4.13.5
@@ -222,7 +222,7 @@ importers:
         version: 8.5.26
       postcss-loader:
         specifier: ^8.2.1
-        version: 8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@7.0.2)
+        version: 8.2.1(@rspack/core@2.2.1)(postcss@8.5.26)(typescript@7.0.2)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -236,11 +236,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rspack/core':
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.2.1
+        version: 2.2.1
       '@types/node':
-        specifier: ^26.2.0
-        version: 26.2.0
+        specifier: ^26.4.0
+        version: 26.4.0
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -339,32 +339,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260811.1':
-    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
+  '@cloudflare/workerd-darwin-64@1.20260828.1':
+    resolution: {integrity: sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
-    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
+  '@cloudflare/workerd-darwin-arm64@1.20260828.1':
+    resolution: {integrity: sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260811.1':
-    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
+  '@cloudflare/workerd-linux-64@1.20260828.1':
+    resolution: {integrity: sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260811.1':
-    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
+  '@cloudflare/workerd-linux-arm64@1.20260828.1':
+    resolution: {integrity: sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260811.1':
-    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
+  '@cloudflare/workerd-windows-64@1.20260828.1':
+    resolution: {integrity: sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -804,88 +804,88 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@rspack/binding-darwin-arm64@2.2.0':
-    resolution: {integrity: sha512-KAVVT7hp3NBjtc/RY2UtOjzzc8i+s4pIhW1p52UV+Aev6ywQCu3dXwkHTonpPvJO3hqLXc4zIMH5l4HbMqBm4g==}
+  '@rspack/binding-darwin-arm64@2.2.1':
+    resolution: {integrity: sha512-Y/Naw/7V76QiUYdYRuBzBZtzRjt/3fjDUuF8GK0+/BO7BP1RrpY4tk1ln+iiqegRUD8u9uGn08fi8No1rwfyUg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.2.0':
-    resolution: {integrity: sha512-rzyJCX99aFwl540trsVMNZOgK4+IFm2d5+YeP+RdNo9Uprxloz8vHz0J4dYtaq6MRiCAyM60dAwEa3wJMwqWAQ==}
+  '@rspack/binding-darwin-x64@2.2.1':
+    resolution: {integrity: sha512-rTIG/xZIW7RbEEuMR9hnNn5dv3fDBpX0N4FAQUwfhUYy3tN2+3vibTTq/Nj1Sd9Vn4yWydbWIEwBX6m/aGejig==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.2.0':
-    resolution: {integrity: sha512-0t8QOiOMcBV7RvPSsTJ5DQ4QCK6FIyUZy77qbxnS6asGTOXPZZn7V5cL26IxEv/wuHdQ6tQOXheau1fi+gGyBQ==}
+  '@rspack/binding-linux-arm64-gnu@2.2.1':
+    resolution: {integrity: sha512-53rAMU6Hqiat21IMU1hTt4Si2F33h+ZbXOt+Y18W39AFjcwmleIBId2u7beqJeGXLJuBgIAm31jcbJj/PN7mWQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.2.0':
-    resolution: {integrity: sha512-BAvCukqcuHxUdE294ITCohvhVkEklW8RbkKkR36Uo0WyIiMPGrnvPjARPn0/4Q4xMAz7lUmC60sZrvJHlAOKMw==}
+  '@rspack/binding-linux-arm64-musl@2.2.1':
+    resolution: {integrity: sha512-o7zFiWkt4MqSfSdTbxUdF27fcrWKpRizcuVB8H3yd2G6xW9V2OfYbhVGQnOlbKi+GK74RkCmoJtANB+QboIqKQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.0':
-    resolution: {integrity: sha512-nCHqZLv/E8nm2ccGkb00F5DQtXxzGy3W3X73ArA+N0+zXJUnzRcSRSwr7AE8pVgP/FYfX4yMFgUXy0g0YxYGRA==}
+  '@rspack/binding-linux-ppc64-gnu@2.2.1':
+    resolution: {integrity: sha512-pvx1oeg1z7cr8OcNt7PAt1SJTHzdsN/pvu7HkGnfks2fWE7GDs9DLL2KvN7tUkzQvJm6bGgUwqSCOrqV4uSwAg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-gnu@2.2.0':
-    resolution: {integrity: sha512-CA3WEqKFDI6FAZTnCho2n9pmdPWZYAW/S8mqgxd0cx2Jix43at3VyLxhCC7ED5A9WBSFn/AdHaIbVtgoQHVhWA==}
+  '@rspack/binding-linux-riscv64-gnu@2.2.1':
+    resolution: {integrity: sha512-WQ6P94Wz2tgwOsgifTWP2/bV63iZH5+rkxngQwF22FC8KmIXXy/Yug7lyMH1ld8Hzg4p1qXjBBr4i1cCyJTR+w==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.2.0':
-    resolution: {integrity: sha512-kHB960oClkoPRPZ6sdkhRvqbdRIlbpIMYd/Tbxfmn3DWQahiCk1pkUFJbOtFq3EgESxZISV4THl442W2Y57HvQ==}
+  '@rspack/binding-linux-riscv64-musl@2.2.1':
+    resolution: {integrity: sha512-GEFUFHQkjKU7OYyHXnrIo8wWcUHM7jeKov5z6Lxd3i+3hKo11yBOgb7b+uD94Rx2tPuWF4jyFdWmcNu46Njb/A==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-s390x-gnu@2.2.0':
-    resolution: {integrity: sha512-lVBdiffVo1jq0P0jT36jNou2suLB4ueQI4aWUs+HM+h67YPBtVKWu/mo5Wh59+8nowgcZmYaFM5hdH69963I9w==}
+  '@rspack/binding-linux-s390x-gnu@2.2.1':
+    resolution: {integrity: sha512-Cqw2UjSmFGZaw1EjQXClKDud86ThynGEEIazy2PZfPzZG4WjICK1WjdeFCJd7xWsSbUQ3jGyzb7/EHiDVa+sKA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-gnu@2.2.0':
-    resolution: {integrity: sha512-M49UaWspE0YJ3268DsquD8idEQTfjBDMvO/I8qccV/Z5T+Q98FJ+kIs5liUaTWb48OIbDEK+8ZKx5QzLbfVN6g==}
+  '@rspack/binding-linux-x64-gnu@2.2.1':
+    resolution: {integrity: sha512-QX+gRxg2CS9ri2fUG5eNurdsrOCWoJ56SsD2O7kcVGiRm+S2+muNb/QhkdkAdt/u/m++7Ve5TMIpHTnaKYCpCw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.2.0':
-    resolution: {integrity: sha512-YYbs0wmey+5blhEQDE4Dax3TwJtqfGwe2QBm3OLphlBHo/fcZVvimzKkMV0/pVrZTLy2z5ZAwNhGMY64bNr77w==}
+  '@rspack/binding-linux-x64-musl@2.2.1':
+    resolution: {integrity: sha512-mBZQl1NdGbEB3y5M9d0tkuF7RL1GLz3Hb3gqFa3QRZBymP9PCV83Jiji8s2PJimNUJIVcdZRIw8+VGYs/35c2A==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.2.0':
-    resolution: {integrity: sha512-rerLPTN/HD4EvLNWs3O2N+Eb37eGvLRIP3dXXc3n+UzTebOepAsahNn44vXeRBsE4m/pHkpDJjwgWTytgQ2gBw==}
+  '@rspack/binding-wasm32-wasi@2.2.1':
+    resolution: {integrity: sha512-/d2ImKDS+lT+FJ07MxKBeUkTat84tr2Nm2+nIRt8HmZK7/N8odkQml9vb4MHr8E7oYOp4B+jm6W5frdRzKrkJQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.2.0':
-    resolution: {integrity: sha512-JUAmnbOQYGTRyX28vls/MOMonZWcmcCi5YtEq6YMc8Xqh3Qx0HUwaLM/I1xr/N9BX3b8CV0dQDOpNuBc2ei+CA==}
+  '@rspack/binding-win32-arm64-msvc@2.2.1':
+    resolution: {integrity: sha512-TfmaKPF3KC7uoZb6A+8ZUbLS8g8P5EdeXFGLCaJ+UgdkJ20TsapcfJXZXWNnKzFEkV8dUO/t5oNxNLYy2URusw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.2.0':
-    resolution: {integrity: sha512-wOmQRUaOG0eWH/fnfslA9yK9xKfaq9X+3Xa1TdTJnTqlo0ARJYs6A+Lzjbs7cxdY/o1f12Xe00BG3nQozReUOg==}
+  '@rspack/binding-win32-ia32-msvc@2.2.1':
+    resolution: {integrity: sha512-rdBXayngvpQFMSUIC4b71FDZrSBJszSHNEkln/Nis3a17DMAE7IkgJcqe7SqLWbk2OPF/N920AOWmBEDQQCaMg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.2.0':
-    resolution: {integrity: sha512-v6/3bFr9+i7hRpgulL9b5qCvZL0VgR4vQGQNqOWezUzZmPUj9LYpvB0L9xZIVwDQ2ug/xBiA58bfg5IbESgoyw==}
+  '@rspack/binding-win32-x64-msvc@2.2.1':
+    resolution: {integrity: sha512-l3K4s7nrQJc+3LacPFjZGjX8Jk1sf8Q4TK6IXAsdSucOjTqYSpD8PMl2NUXCBDXOl8T2V4v323z1LfxwW8BPmA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.2.0':
-    resolution: {integrity: sha512-nxZzJqqB0EmEKp6qjzFNkBb/SgGt0k0DSENrLvAJgvVvrm3waVsubD0cfxtPlZY/rd5SzadzxWGEHRyFcds5nA==}
+  '@rspack/binding@2.2.1':
+    resolution: {integrity: sha512-56TqztuEMd+aHGv1jDXnkJQGSLTb4NoO146flFxJqPG8931UdXPO2pNR9M0Q2Pz+GvmO0fLHGPLYBHoRVrRlHw==}
 
-  '@rspack/core@2.2.0':
-    resolution: {integrity: sha512-3W7oX0BAHbK4VlknH3lfyfRvupzxdZtyEa+DfKmdjzmIAcqYtHnFd0nLqp5dzitDPyDI1TIKkDhpB0AZJn0pVg==}
+  '@rspack/core@2.2.1':
+    resolution: {integrity: sha512-EHFX2oWCY1HkHJkG/Ev8HXCcl4gQzgETyairdIlBkKaypuW8i7kowBxUFzpHHg/ObF70vB3focToel9Wwg4MRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -899,7 +899,7 @@ packages:
   '@rspack/plugin-react-refresh@2.0.2':
     resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
     peerDependencies:
-      '@rspack/core': 2.2.0
+      '@rspack/core': 2.2.1
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       '@rspack/core':
@@ -1053,8 +1053,8 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
-  '@types/markdown-it@14.1.2':
-    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+  '@types/markdown-it@14.2.0':
+    resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -1062,11 +1062,11 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@26.2.0':
-    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
-  '@types/react-dom@19.2.4':
-    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+  '@types/react-dom@19.2.5':
+    resolution: {integrity: sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -1076,63 +1076,63 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.67.0':
-    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
+  '@typescript-eslint/eslint-plugin@8.68.0':
+    resolution: {integrity: sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.67.0
+      '@typescript-eslint/parser': ^8.68.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.67.0':
-    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.67.0':
-    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.67.0':
-    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.67.0':
-    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.67.0':
-    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
+  '@typescript-eslint/parser@8.68.0':
+    resolution: {integrity: sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.67.0':
-    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.67.0':
-    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
+  '@typescript-eslint/project-service@8.68.0':
+    resolution: {integrity: sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.67.0':
-    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+  '@typescript-eslint/scope-manager@8.68.0':
+    resolution: {integrity: sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.68.0':
+    resolution: {integrity: sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.68.0':
+    resolution: {integrity: sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.67.0':
-    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
+  '@typescript-eslint/types@8.68.0':
+    resolution: {integrity: sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.68.0':
+    resolution: {integrity: sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.68.0':
+    resolution: {integrity: sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.68.0':
+    resolution: {integrity: sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -1418,8 +1418,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.8.1:
-    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
+  eslint@10.9.1:
+    resolution: {integrity: sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1729,8 +1729,8 @@ packages:
       '@types/markdown-it': '*'
       markdown-it: '*'
 
-  markdown-it@15.0.0:
-    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
+  markdown-it@15.0.1:
+    resolution: {integrity: sha512-9/7gE95FNPkfUWrjJIoHZza2iLmuJlPD0UNMxPi7bxUrbCR525YZY0r+zyfes0dZI5ZZ/uNIXUJca0pJvtw41g==}
     hasBin: true
 
   mdast-util-to-hast@13.2.1:
@@ -1754,8 +1754,8 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
-  miniflare@5.20260811.1-alpha:
-    resolution: {integrity: sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==}
+  miniflare@5.20260828.0-alpha:
+    resolution: {integrity: sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
@@ -1838,7 +1838,7 @@ packages:
     resolution: {integrity: sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 2.2.0
+      '@rspack/core': 2.2.1
       postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.0.0
     peerDependenciesMeta:
@@ -1889,7 +1889,7 @@ packages:
     resolution: {integrity: sha512-KqDzmxBUZEcAphwg/PnEHOBkqTJjesTmLoBygLHie1gkiLINiZuVKPRccS6qDzfdj9ccYCaJ743IDYVh0wPf/w==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      '@rspack/core': 2.2.0
+      '@rspack/core': 2.2.1
       react: 19.2.8
       react-dom: 19.2.8
 
@@ -1993,8 +1993,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript-eslint@8.67.0:
-    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
+  typescript-eslint@8.68.0:
+    resolution: {integrity: sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2062,17 +2062,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260811.1:
-    resolution: {integrity: sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==}
+  workerd@1.20260828.1:
+    resolution: {integrity: sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.123.0:
-    resolution: {integrity: sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==}
+  wrangler@4.127.1:
+    resolution: {integrity: sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260811.1
+      '@cloudflare/workers-types': ^5.20260828.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -2232,25 +2232,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260811.1
+      workerd: 1.20260828.1
 
-  '@cloudflare/workerd-darwin-64@1.20260811.1':
+  '@cloudflare/workerd-darwin-64@1.20260828.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260828.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260811.1':
+  '@cloudflare/workerd-linux-64@1.20260828.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+  '@cloudflare/workerd-linux-arm64@1.20260828.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260811.1':
+  '@cloudflare/workerd-windows-64@1.20260828.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -2351,9 +2351,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.9.1(jiti@2.7.0))':
     dependencies:
-      eslint: 10.8.1(jiti@2.7.0)
+      eslint: 10.9.1(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2374,9 +2374,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.9.1(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.8.1(jiti@2.7.0)
+      eslint: 10.9.1(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -2558,78 +2558,78 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@rspack/binding-darwin-arm64@2.2.0':
+  '@rspack/binding-darwin-arm64@2.2.1':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.2.0':
+  '@rspack/binding-darwin-x64@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.2.0':
+  '@rspack/binding-linux-arm64-gnu@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.2.0':
+  '@rspack/binding-linux-arm64-musl@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.0':
+  '@rspack/binding-linux-ppc64-gnu@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.2.0':
+  '@rspack/binding-linux-riscv64-gnu@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.2.0':
+  '@rspack/binding-linux-riscv64-musl@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-s390x-gnu@2.2.0':
+  '@rspack/binding-linux-s390x-gnu@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.2.0':
+  '@rspack/binding-linux-x64-gnu@2.2.1':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.2.0':
+  '@rspack/binding-linux-x64-musl@2.2.1':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.2.0':
+  '@rspack/binding-wasm32-wasi@2.2.1':
     dependencies:
       '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.2.0':
+  '@rspack/binding-win32-arm64-msvc@2.2.1':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.2.0':
+  '@rspack/binding-win32-ia32-msvc@2.2.1':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.2.0':
+  '@rspack/binding-win32-x64-msvc@2.2.1':
     optional: true
 
-  '@rspack/binding@2.2.0':
+  '@rspack/binding@2.2.1':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.2.0
-      '@rspack/binding-darwin-x64': 2.2.0
-      '@rspack/binding-linux-arm64-gnu': 2.2.0
-      '@rspack/binding-linux-arm64-musl': 2.2.0
-      '@rspack/binding-linux-ppc64-gnu': 2.2.0
-      '@rspack/binding-linux-riscv64-gnu': 2.2.0
-      '@rspack/binding-linux-riscv64-musl': 2.2.0
-      '@rspack/binding-linux-s390x-gnu': 2.2.0
-      '@rspack/binding-linux-x64-gnu': 2.2.0
-      '@rspack/binding-linux-x64-musl': 2.2.0
-      '@rspack/binding-wasm32-wasi': 2.2.0
-      '@rspack/binding-win32-arm64-msvc': 2.2.0
-      '@rspack/binding-win32-ia32-msvc': 2.2.0
-      '@rspack/binding-win32-x64-msvc': 2.2.0
+      '@rspack/binding-darwin-arm64': 2.2.1
+      '@rspack/binding-darwin-x64': 2.2.1
+      '@rspack/binding-linux-arm64-gnu': 2.2.1
+      '@rspack/binding-linux-arm64-musl': 2.2.1
+      '@rspack/binding-linux-ppc64-gnu': 2.2.1
+      '@rspack/binding-linux-riscv64-gnu': 2.2.1
+      '@rspack/binding-linux-riscv64-musl': 2.2.1
+      '@rspack/binding-linux-s390x-gnu': 2.2.1
+      '@rspack/binding-linux-x64-gnu': 2.2.1
+      '@rspack/binding-linux-x64-musl': 2.2.1
+      '@rspack/binding-wasm32-wasi': 2.2.1
+      '@rspack/binding-win32-arm64-msvc': 2.2.1
+      '@rspack/binding-win32-ia32-msvc': 2.2.1
+      '@rspack/binding-win32-x64-msvc': 2.2.1
 
-  '@rspack/core@2.2.0':
+  '@rspack/core@2.2.1':
     dependencies:
-      '@rspack/binding': 2.2.0
+      '@rspack/binding': 2.2.1
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.2.0
+      '@rspack/core': 2.2.1
 
   '@shikijs/core@4.4.3':
     dependencies:
@@ -2761,7 +2761,7 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
-  '@types/markdown-it@14.1.2':
+  '@types/markdown-it@14.2.0':
     dependencies:
       '@types/linkify-it': 5.0.0
       '@types/mdurl': 2.0.0
@@ -2772,11 +2772,11 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@26.2.0':
+  '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
 
-  '@types/react-dom@19.2.4(@types/react@19.2.18)':
+  '@types/react-dom@19.2.5(@types/react@19.2.18)':
     dependencies:
       '@types/react': 19.2.18
 
@@ -2786,15 +2786,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.67.0
-      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.67.0
-      eslint: 10.8.1(jiti@2.7.0)
+      '@typescript-eslint/parser': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/type-utils': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.68.0
+      eslint: 10.9.1(jiti@2.7.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -2802,56 +2802,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.67.0
-      '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.67.0
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.68.0
       debug: 4.4.3
-      eslint: 10.8.1(jiti@2.7.0)
+      eslint: 10.9.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.67.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.68.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.68.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.67.0':
+  '@typescript-eslint/scope-manager@8.68.0':
     dependencies:
-      '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/visitor-keys': 8.67.0
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/visitor-keys': 8.68.0
 
-  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.68.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.8.1(jiti@2.7.0)
+      eslint: 10.9.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.67.0': {}
+  '@typescript-eslint/types@8.68.0': {}
 
-  '@typescript-eslint/typescript-estree@8.67.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.68.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/visitor-keys': 8.67.0
+      '@typescript-eslint/project-service': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/visitor-keys': 8.68.0
       debug: 4.4.3
       minimatch: 10.2.6
       semver: 7.8.5
@@ -2861,20 +2861,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.67.0
-      '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      eslint: 10.8.1(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.68.0
+      '@typescript-eslint/types': 8.68.0
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
+      eslint: 10.9.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.67.0':
+  '@typescript-eslint/visitor-keys@8.68.0':
     dependencies:
-      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/types': 8.68.0
       eslint-visitor-keys: 5.0.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -2994,15 +2994,6 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.1
-      js-yaml: 4.3.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 6.0.3
-
   cosmiconfig@9.0.2(typescript@7.0.2):
     dependencies:
       env-paths: 2.2.1
@@ -3084,11 +3075,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.8.1(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.9.1(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
-      eslint: 10.8.1(jiti@2.7.0)
+      eslint: 10.9.1(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
@@ -3106,9 +3097,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.1(jiti@2.7.0):
+  eslint@10.9.1(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0
@@ -3382,12 +3373,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  markdown-it-anchor@9.2.1(@types/markdown-it@14.1.2)(markdown-it@15.0.0):
+  markdown-it-anchor@9.2.1(@types/markdown-it@14.2.0)(markdown-it@15.0.1):
     dependencies:
-      '@types/markdown-it': 14.1.2
-      markdown-it: 15.0.0
+      '@types/markdown-it': 14.2.0
+      markdown-it: 15.0.1
 
-  markdown-it@15.0.0:
+  markdown-it@15.0.1:
     dependencies:
       argparse: 3.0.0
       entities: 8.0.0
@@ -3427,12 +3418,12 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  miniflare@5.20260811.1-alpha:
+  miniflare@5.20260828.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
       undici: 7.29.0
-      workerd: 1.20260811.1
+      workerd: 1.20260828.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -3507,25 +3498,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-loader@8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@6.0.3):
-    dependencies:
-      cosmiconfig: 9.0.2(typescript@6.0.3)
-      jiti: 2.7.0
-      postcss: 8.5.26
-      semver: 7.8.5
-    optionalDependencies:
-      '@rspack/core': 2.2.0
-    transitivePeerDependencies:
-      - typescript
-
-  postcss-loader@8.2.1(@rspack/core@2.2.0)(postcss@8.5.26)(typescript@7.0.2):
+  postcss-loader@8.2.1(@rspack/core@2.2.1)(postcss@8.5.26)(typescript@7.0.2):
     dependencies:
       cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.7.0
       postcss: 8.5.26
       semver: 7.8.5
     optionalDependencies:
-      '@rspack/core': 2.2.0
+      '@rspack/core': 2.2.1
     transitivePeerDependencies:
       - typescript
 
@@ -3556,9 +3536,9 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-server-dom-rspack@0.1.0(@rspack/core@2.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-server-dom-rspack@0.1.0(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@rspack/core': 2.2.0
+      '@rspack/core': 2.2.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -3675,13 +3655,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.8.1(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.9.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3770,24 +3750,24 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260811.1:
+  workerd@1.20260828.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260811.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260811.1
-      '@cloudflare/workerd-linux-64': 1.20260811.1
-      '@cloudflare/workerd-linux-arm64': 1.20260811.1
-      '@cloudflare/workerd-windows-64': 1.20260811.1
+      '@cloudflare/workerd-darwin-64': 1.20260828.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260828.1
+      '@cloudflare/workerd-linux-64': 1.20260828.1
+      '@cloudflare/workerd-linux-arm64': 1.20260828.1
+      '@cloudflare/workerd-windows-64': 1.20260828.1
 
-  wrangler@4.123.0:
+  wrangler@4.127.1:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260811.1-alpha
+      miniflare: 5.20260828.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260811.1
+      workerd: 1.20260828.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ overrides:
   react: 19.2.8
   react-dom: 19.2.8
   react-server-dom-rspack: 0.1.0
-  '@rspack/core': 2.2.0
+  '@rspack/core': 2.2.1
 allowBuilds:
   esbuild: false
   # wrangler brings workerd, whose install script only picks the platform binary out of the optional

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ packages:
 overrides:
   react: 19.2.8
   react-dom: 19.2.8
-  react-server-dom-rspack: 0.0.3
-  '@rspack/core': 2.1.7
+  react-server-dom-rspack: 0.1.0
+  '@rspack/core': 2.2.0
 allowBuilds:
   esbuild: false
   # wrangler brings workerd, whose install script only picks the platform binary out of the optional

--- a/scripts/check-pinned-deps.mjs
+++ b/scripts/check-pinned-deps.mjs
@@ -1,0 +1,147 @@
+// Checks that the exactly-pinned dependencies agree everywhere they are written down.
+//
+// RSC internals are coupled across builds — `react-server-dom-rspack` reaches into `ReactSharedInternals`
+// and emits a flight payload the matching `react-dom` has to parse, and its `@rspack/core` peer range moves
+// with it — so the coupled set is pinned in three places at once: the two published manifests, and the
+// `overrides` in `pnpm-workspace.yaml` that force one resolution on every workspace member and fixture.
+// Three copies of one fact, and nothing made them agree.
+//
+// They once did not. `6d8e3e4` moved the manifests to `@rspack/core` 2.2.0 / `react-server-dom-rspack` 0.1.0
+// and left the overrides on 2.1.7 / 0.0.3, so the suite, CI and every fixture ran against one pair while
+// `npm i @rshono/core` would have installed the other — for a month, silently, because a manifest pin is
+// what a consumer resolves and an override is what this repo resolves, and no check compared them. That is
+// the whole reason this file exists: the version the suite tests has to be the version a consumer gets.
+//
+// Reported here rather than as a unit test because the invariant spans both published packages and the root
+// workspace file, which neither package's own suite owns. Wired into the `lint` CI job and into
+// `scripts/release.mjs`, so it holds for a laptop release too.
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// The manifests a consumer installs. `peerDependencies` are deliberately wide ranges — the pins are what the
+// framework is *tested* against, the peers are what it *accepts* — so only these two fields are compared.
+const MANIFESTS = ['packages/core/package.json', 'packages/create/package.json'];
+const PINNED_FIELDS = ['dependencies', 'devDependencies'];
+
+/** An exact version, as every override has to be: no `^`, no `~`, no range, no tag. */
+const EXACT = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/;
+
+/**
+ * The `overrides:` block of a pnpm YAML file, without a YAML parser — the block is flat `name: version`
+ * pairs and the two files that carry one are both in this repo.
+ *
+ * Strict on purpose. A line it cannot account for throws rather than being skipped, because the failure mode
+ * this whole file guards against is a pin that silently went unchecked.
+ */
+function readOverrides(relPath) {
+  const lines = readFileSync(join(rootDir, relPath), 'utf8').split(/\r?\n/);
+  const start = lines.indexOf('overrides:');
+  if (start === -1) throw new Error(`${relPath} has no \`overrides:\` block — the pins are no longer where this check looks for them.`);
+
+  const overrides = new Map();
+  for (const [offset, line] of lines.slice(start + 1).entries()) {
+    if (line.trim() === '' || line.trimStart().startsWith('#')) continue;
+    // The block ends at the first line that is not indented, i.e. the next top-level key.
+    if (!/^\s/.test(line)) break;
+    const entry = /^\s+'?([^':\s]+)'?:\s*'?([^'\s#]+)'?\s*(?:#.*)?$/.exec(line);
+    if (!entry) throw new Error(`${relPath}:${start + 2 + offset} is inside \`overrides:\` but is not a \`name: version\` pair: ${line.trim()}`);
+    overrides.set(entry[1], entry[2]);
+  }
+
+  if (overrides.size === 0) throw new Error(`${relPath} has an empty \`overrides:\` block.`);
+  return overrides;
+}
+
+/** The version of `name` as the package in `packageDir` actually resolves it, or `undefined` if it has none. */
+function installedVersion(packageDir, name) {
+  try {
+    const require = createRequire(join(rootDir, packageDir, 'package.json'));
+    return require(`${name}/package.json`).version;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Every disagreement between the overrides, the manifests, the lockfile and what is installed, as lines
+ * ready to print. Empty means they agree.
+ */
+export function checkPinnedDeps() {
+  const overrides = readOverrides('pnpm-workspace.yaml');
+  const problems = [];
+  // Which pins were compared against a real install, so the summary claims only what it checked: a tree that
+  // has not been installed yet answers for the files alone.
+  const resolved = new Set();
+
+  // The lockfile restates the overrides it was resolved with, so this is the "you edited the workspace file
+  // and did not install" check. CI's `--frozen-lockfile` also catches it; a laptop release does not install.
+  const locked = readOverrides('pnpm-lock.yaml');
+  for (const [name, version] of overrides) {
+    const lockedVersion = locked.get(name);
+    if (lockedVersion !== version) {
+      problems.push(
+        `pnpm-lock.yaml was resolved with ${name} ${lockedVersion ?? '(no override)'}, but pnpm-workspace.yaml now pins ${version} — run \`pnpm install\``,
+      );
+    }
+  }
+
+  for (const relPath of MANIFESTS) {
+    const manifest = JSON.parse(readFileSync(join(rootDir, relPath), 'utf8'));
+    const packageDir = dirname(relPath);
+
+    for (const field of PINNED_FIELDS) {
+      for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+        const pinned = overrides.get(name);
+        if (pinned === undefined) continue;
+
+        if (range !== pinned) {
+          problems.push(
+            `${relPath} declares ${field}.${name} as ${range}, but pnpm-workspace.yaml pins ${pinned} — ` +
+              `a consumer resolves the manifest, this repo resolves the override, so these are two different tested versions`,
+          );
+        }
+
+        // What the suite actually ran against. Catches a stale `node_modules` that agrees with nothing.
+        const installed = installedVersion(packageDir, name);
+        if (installed !== undefined) resolved.add(name);
+        if (installed !== undefined && installed !== pinned) {
+          problems.push(`${packageDir} has ${name} ${installed} installed, but the pin is ${pinned} — run \`pnpm install\``);
+        }
+      }
+    }
+  }
+
+  for (const [name, version] of overrides) {
+    if (!EXACT.test(version)) {
+      problems.push(
+        `pnpm-workspace.yaml pins ${name} as ${version}, which is a range — the coupled set has to be exact or a resolution can move underneath a release`,
+      );
+    }
+  }
+
+  return { overrides, problems, resolved };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { overrides, problems, resolved } = checkPinnedDeps();
+
+  if (problems.length > 0) {
+    console.error('\n✗ the exact pins disagree\n');
+    for (const problem of problems) console.error(`  ${problem}`);
+    console.error(
+      '\n  Every pin is written in three places — packages/core/package.json, packages/create/package.json and\n' +
+        '  the `overrides` in pnpm-workspace.yaml — plus the lockfile. Move all of them together, then re-run the\n' +
+        '  whole suite: a bump to this set is a release. See CONTRIBUTING.md.\n',
+    );
+    process.exit(1);
+  }
+
+  for (const [name, version] of overrides) {
+    const sources = resolved.has(name) ? 'manifests, overrides, lockfile and node_modules' : 'manifests, overrides and lockfile';
+    console.log(`  ✓ ${name} ${version} — ${sources} agree`);
+  }
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -5,13 +5,16 @@
 // produce. Packages released this way show on npm without their verified-build link.
 //
 // Because no CI job stands between a mistake and the registry, every gate is applied here before anything is
-// uploaded — clean tree, the two manifests agreeing, an annotated tag at HEAD, the version not already
-// published, and the whole suite green. npm's two-factor prompt is handled by letting pnpm own the terminal:
-// it asks for the one-time code itself when the registry demands one.
+// uploaded — clean tree, the two manifests agreeing, the exact pins agreeing with the workspace overrides and
+// the lockfile, an annotated tag at HEAD, the version not already published, and the whole suite green. npm's
+// two-factor prompt is handled by letting pnpm own the terminal: it asks for the one-time code itself when the
+// registry demands one.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { checkPinnedDeps } from './check-pinned-deps.mjs';
 
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 // The only two manifests that are not `private`. Kept explicit rather than discovered so that a new package
@@ -131,6 +134,21 @@ if (manifests.some((manifest) => manifest.version !== version)) {
   );
 }
 ok(`both packages are ${version}`);
+
+// A manifest pin is what a consumer resolves; a `pnpm-workspace.yaml` override is what this repo resolves.
+// Drifted, the suite below is green against a resolution nobody can install, which is how 2.2.0/0.1.0 sat
+// untested in the manifests for a month. Checked in this step rather than among the gates so that
+// `--skip-tests` cannot skip it: it is a property of the files being uploaded, not of a test run.
+const { overrides, problems } = checkPinnedDeps();
+if (problems.length > 0) {
+  fail(
+    'the exactly-pinned dependencies disagree',
+    ...problems,
+    '',
+    'move the manifests, the overrides and the lockfile together, then re-run the suite — a bump to this set is a release',
+  );
+}
+ok(`${overrides.size} exact pins agree across the manifests, the overrides and the lockfile`);
 
 // The tag stays the record of what was released even though it is no longer what triggers the release, so a
 // local publish refuses to run ahead of one. Annotated, because `git push --follow-tags` ignores lightweight


### PR DESCRIPTION
- Test the dependency versions that actually get published
- Update every dependency to its latest release
- Serve prerendered pages whose paths need percent-encoding
- Drop 'head' from HTTPMethod — it could never match
- Validate src/routes.ts and src/server.ts instead of casting them
- Shadow the process binding, not the text "process.env"
- Mount /_static after src/server.ts, not ahead of it
- Refuse a same-site form post to a server action, not only cross-site
- Make the form-post guard prove same-origin rather than not-foreign
- Validate the CSP nonce before writing it into a script tag
- Warn when nothing in src/ registers a body cap
- Write down that a client action rides on the CORS preflight
- Tidy two loose ends from the security pass
- Read PORT the same way in the CLI and in the bundle
- Answer an action with something the caller can act on
- Answer for a notFound page that cannot render itself
- Stop rendering a page a late redirect() has already discarded
- Answer a HEAD without rendering a page nobody reads
- Write down that a page answers GET, POST and HEAD, and nothing else
- Let the build tell the runtime what it prerendered
- Say what a plain-text 404 promises about caching
- Skip a route that cannot be prerendered instead of failing the build
- Declare the not-found payload as one from both routes
- Park the flight injector on what the consumer asked for
- Guard against a document trailer split across two batches
- Prerender paths concurrently, and each one once
- Give an onServerError handler the context a report needs
- Let an endpoint route name more than one method
- Check staticPaths against its own route's path
- Say that the throw-only context members are permanent
- Write down what a non-enumerable ctx prop costs
- Say in the trustProxy JSDoc what only the README said
- Make the ESM-only surface and the dev-only stack explicit
- Document how to change a prerendered page's cache policy
- Name publicUrl where the package documentation lists the surface
- Make the prerender traversal test prove something
- Unit-test publicUrl, loadConfig and the error funnel
- Assert that defineRoutes still rejects what it is meant to
- Prove two in-flight requests keep separate contexts
- Add a coverage floor, and an OPTIONS endpoint to answer for
- Record the whole hardening pass in the changelog
- Say what the permit gate costs, and be exact about the count
- Run Prettier over the files this pass touched
